### PR TITLE
P0-004: Add pgenlib, libdeflate, and vendored zstd build integration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,6 +64,7 @@ set_target_properties(plink_libdeflate PROPERTIES
 
 # --- zstd (C library, pgenlib's vendored copy) ---
 # Hidden visibility is critical to avoid symbol collisions with DuckDB's bundled zstd.
+# GLOB is acceptable here because the submodule is pinned; re-run cmake if pin changes.
 file(GLOB PLINK_ZSTD_COMMON_SRCS ${ZSTD_DIR}/lib/common/*.c)
 file(GLOB PLINK_ZSTD_DECOMPRESS_SRCS ${ZSTD_DIR}/lib/decompress/*.c)
 file(GLOB PLINK_ZSTD_COMPRESS_SRCS ${ZSTD_DIR}/lib/compress/*.c)
@@ -72,7 +73,9 @@ add_library(plink_zstd STATIC
     ${PLINK_ZSTD_DECOMPRESS_SRCS}
     ${PLINK_ZSTD_COMPRESS_SRCS}
 )
-target_include_directories(plink_zstd PUBLIC
+# PRIVATE: don't leak vendored zstd headers to extension targets (collision risk
+# with DuckDB's own bundled zstd headers).
+target_include_directories(plink_zstd PRIVATE
     ${ZSTD_DIR}/lib
     ${ZSTD_DIR}/lib/common
 )
@@ -83,6 +86,8 @@ set_target_properties(plink_zstd PROPERTIES
 )
 
 # --- pgenlib (C++ library) ---
+# Read-path only — pgenlib_write.cc, plink2_bitmap.cc, plink2_fmath.cc,
+# plink2_stats.cc are intentionally excluded.
 add_library(pgenlib STATIC
     ${PGENLIB_DIR}/plink2_base.cc
     ${PGENLIB_DIR}/plink2_bits.cc
@@ -103,6 +108,10 @@ target_include_directories(pgenlib PUBLIC
     ${LIBDEFLATE_DIR}
     ${SIMDE_DIR}
 )
+target_include_directories(pgenlib PRIVATE
+    ${ZSTD_DIR}/lib
+    ${ZSTD_DIR}/lib/common
+)
 target_link_libraries(pgenlib PRIVATE plink_libdeflate plink_zstd)
 target_compile_definitions(pgenlib PRIVATE
     ZSTD_DISABLE_ASM
@@ -114,11 +123,15 @@ target_link_libraries(pgenlib PRIVATE ZLIB::ZLIB Threads::Threads)
 set_target_properties(pgenlib PROPERTIES
     CXX_VISIBILITY_PRESET hidden
     C_VISIBILITY_PRESET hidden
+    VISIBILITY_INLINES_HIDDEN ON
     POSITION_INDEPENDENT_CODE ON
     CXX_STANDARD 17
 )
 
 # --- Link pgenlib and its dependencies to extension targets ---
+# Deps are listed explicitly because pgenlib links them PRIVATE (won't propagate
+# in static builds) and DuckDB's macros require the plain target_link_libraries
+# signature (no PRIVATE/PUBLIC keyword).
 target_link_libraries(${EXTENSION_NAME} pgenlib plink_libdeflate plink_zstd ZLIB::ZLIB Threads::Threads)
 target_link_libraries(${LOADABLE_EXTENSION_NAME} pgenlib plink_libdeflate plink_zstd ZLIB::ZLIB Threads::Threads)
 target_include_directories(${EXTENSION_NAME} PRIVATE ${PGENLIB_DIR})


### PR DESCRIPTION
## Summary

- Builds three static libraries from the `plink-ng` submodule (at pinned commit `4ce97faa`) and links them into the extension:
  - **plink_libdeflate** — libdeflate (C), for BGZF decompression
  - **plink_zstd** — vendored zstd (C), for .zst file support
  - **pgenlib** — plink2 genomics library (C++17), the core reader
- Hidden visibility (`-fvisibility=hidden`) on all three libraries prevents symbol collisions with DuckDB's own bundled zstd
- Early-fail CMake check if the submodule is not initialized

## Considerations

- **DuckDB export set compatibility**: DuckDB's `build_static_extension()` macro uses the plain (no-keyword) `target_link_libraries` signature. CMake forbids mixing plain and keyword signatures on the same target, so our link calls must also use the plain signature. This means our static libraries become implicit public dependencies and must be added to the `DUCKDB_EXPORT_SET` install to satisfy CMake's export validation.
- **zstd symbol isolation**: Hidden visibility is the first line of defense. If symbol collisions surface on other platforms/link modes, escalation options include `objcopy --prefix-symbols` or zstd's `ZSTD_LIB_NAME_PREFIX` compile flag.
- **plink2_thread.cc**: Compiles successfully (other pgenlib code references its symbols) but its threading functions are never invoked — DuckDB controls all parallelism. No stubs were needed.
- **Platform portability**: libdeflate's ARM/x86 CPU feature sources are preprocessor-guarded; both compile cleanly on x86. ARM not yet tested.

## Test plan

- [x] `make clean && make` — release build succeeds
- [x] `make debug` — debug build succeeds
- [x] `make test` — extension load test passes
- [x] `nm -D` on loadable extension shows zero leaked zstd symbols

🤖 Generated with [Claude Code](https://claude.com/claude-code)