### PR TITLE
Update docs for P2-001 completion

### DIFF
--- a/docs/planning/P2-001-plink-freq
+++ b/docs/planning/P2-001-plink-freq
@@ -438,16 +438,29 @@ SELECT * FROM plink_freq('data/example.pgen', region := '22:1-50000000');
 
 ## Acceptance Criteria
 
-1. [ ] `plink_freq('file.pgen')` returns correct allele frequencies for known test data
-2. [ ] Frequencies match hand-calculated values from the test VCF
-3. [ ] Auto-discovery of .pvar and .psam works
-4. [ ] Named parameters `pvar` and `psam` override auto-discovery
-5. [ ] `counts := true` adds HOM_REF_CT, HET_CT, HOM_ALT_CT, MISSING_CT columns
-6. [ ] `samples` parameter correctly subsets and recalculates frequencies
-7. [ ] `region` parameter filters to variants in the specified range
-8. [ ] Empty region returns 0 rows
-9. [ ] Shared utilities extracted to `plink_common.hpp/cpp`
-10. [ ] `read_pgen` refactored to use shared utilities (existing tests pass)
-11. [ ] All positive and negative tests pass
-12. [ ] `make test` passes
-13. [ ] README updated
+1. [x] `plink_freq('file.pgen')` returns correct allele frequencies for known test data
+2. [x] Frequencies match hand-calculated values from the test VCF
+3. [x] Auto-discovery of .pvar and .psam works
+4. [x] Named parameters `pvar` and `psam` override auto-discovery
+5. [x] `counts := true` adds HOM_REF_CT, HET_CT, HOM_ALT_CT, MISSING_CT columns
+6. [x] `samples` parameter correctly subsets and recalculates frequencies
+7. [x] `region` parameter filters to variants in the specified range
+8. [x] Empty region returns 0 rows
+9. [x] Shared utilities extracted to `plink_common.hpp/cpp`
+10. [x] `read_pgen` refactored to use shared utilities (existing tests pass)
+11. [x] All positive and negative tests pass
+12. [x] `make test` passes (877 assertions, 14 test cases)
+13. [ ] README updated (deferred — no README exists yet)
+
+## Implementation Notes
+
+- **Dosage mode deferred**: `dosage := true` parameter is registered but throws
+  `NotImplementedException`. No test data with dosage information is available.
+  Will be implemented when dosage test fixtures are created.
+- **Projection pushdown**: frequency columns are only computed when projected.
+  Guard against `COLUMN_IDENTIFIER_ROW_ID` (UINT64_MAX) in column ID checks.
+- **LoadVariantMetadata**: reads file once via ReadFileLines and parses header
+  inline from in-memory lines (avoids double file read).
+- **samples parameter**: uses `LogicalType::ANY` to support both LIST(VARCHAR)
+  and LIST(INTEGER) dispatch.
+- **Merged**: PR #12, 2026-02-26

--- a/docs/planning/PLAN-INDEX
+++ b/docs/planning/PLAN-INDEX
@@ -42,26 +42,26 @@ PR #10 added read_pgen test coverage, fixed the CI zlib dependency, added a
 musl rawmemchr shim, and excluded non-Linux platforms (macOS, Windows, WASM,
 musl) from CI due to pre-existing plink-ng portability issues.
 
-### P2 — Utility Functions (Ready)
+### P2 — Utility Functions (In Progress)
 
 Planned by P1-006. Five functions approved after surveying plink2's full
 analytical command set. See `P1-006-research-summary` for the complete
 survey, evaluation criteria, and deferred candidates.
 
-P1 is complete — P2 can begin.
+P2-001 is complete — shared infrastructure is in place. Group B can begin.
 
 | Plan | Title | Depends On | Branch | Parallel Group | Status |
 |------|-------|-----------|--------|----------------|--------|
-| P2-001 | plink_freq (allele frequencies) | P1-003 | `feature/P2-001-plink-freq` | **A** (first — creates shared infra) | Planned |
+| P2-001 | plink_freq (allele frequencies) | P1-003 | `feature/P2-001-plink-freq` | **A** (first — creates shared infra) | ✓ Merged (PR #12) |
 | P2-002 | plink_hardy (HWE exact test) | P2-001 | `feature/P2-002-plink-hardy` | **B** | Planned |
 | P2-003 | plink_missing (missingness rates) | P2-001 | `feature/P2-003-plink-missing` | **B** | Planned |
 | P2-004 | plink_ld (linkage disequilibrium) | P2-001 | `feature/P2-004-plink-ld` | **B** | Planned |
 | P2-005 | plink_score (polygenic scoring) | P2-001 | `feature/P2-005-plink-score` | **B** | Planned |
 
-**P2-001 runs first** — it extracts shared infrastructure (RAII wrappers,
-PgenContext, sample subsetting, region filtering) from `read_pgen` into
-`plink_common.hpp/cpp`. P2-002 through P2-005 are independent and run in
-parallel after P2-001 merges.
+**P2-001 complete** — shared infrastructure (AlignedBuffer, SampleSubset,
+VariantRange, companion file discovery) extracted into `plink_common.hpp/cpp`.
+`read_pgen` refactored to use shared utilities. Dosage mode deferred (no test
+data). P2-002 through P2-005 are independent and run in parallel.
 
 ### P3 — Advanced Functions (Future)
 


### PR DESCRIPTION
## Summary
- Update CLAUDE.md with plink_common/plink_freq in project structure, shared P2 infrastructure pattern, and PgrGetCounts pgenlib notes
- Mark P2-001 as merged in PLAN-INDEX, update P2 section status
- Check acceptance criteria in P2-001 plan, add implementation notes

Follow-up to PR #12 (plink_freq implementation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)