### PR TITLE
Optimize bind-time loaders for biobank-scale random access

### DIFF
--- a/src/include/plink_common.hpp
+++ b/src/include/plink_common.hpp
@@ -132,6 +132,13 @@ struct VariantMetadataIndex {
 	//! Sparse mode: file-row vidx → local index in the vectors. Empty in dense mode.
 	unordered_map<uint32_t, uint32_t> vidx_map;
 
+	//! Sparse mode: local index → file-row vidx (reverse of vidx_map).
+	//! Empty in dense mode (where local index == file-row vidx).
+	//! Keeping both directions lets Local()/GetChrom()/etc. stay O(1) AND lets
+	//! scan/filter code look up "what file-row vidx is this local row?" in O(1)
+	//! (used by ResolveByCpra and BuildVariantIdIndex in sparse mode).
+	vector<uint32_t> local_to_vidx;
+
 	//! Chromosome offset index for fast region lookups (dense mode only).
 	//! chrom → [first_local_idx, past_end_local_idx). Assumes variants are
 	//! (CHROM, POS)-sorted as required by the PLINK spec.
@@ -188,7 +195,24 @@ struct VariantMetadataIndex {
 	inline const string &GetAlt(idx_t vidx) const {
 		return alts[Local(vidx)];
 	}
+
+	//! Map a local index (into chroms/positions/ids/refs/alts) back to a file-row vidx.
+	//! O(1) in both modes. Use this when iterating the loaded subset (e.g. all of
+	//! chroms.size()) and you need the pgenlib-compatible vidx for each row.
+	inline uint32_t VidxForLocal(idx_t local) const {
+		if (local_to_vidx.empty()) {
+			return static_cast<uint32_t>(local); // dense: local == vidx
+		}
+		return local_to_vidx[local];
+	}
 };
+
+//! Build a map from variant ID (rsid) to file-row vidx. Handles both dense and
+//! sparse variant indexes: in sparse mode only the loaded subset is indexed
+//! (which is the correct semantic — user-supplied rsids can only resolve to
+//! variants that are actually in the loaded subset, typically a region).
+//! Empty IDs are skipped.
+unordered_map<string, uint32_t> BuildVariantIdIndex(const VariantMetadataIndex &variants);
 
 //! Build an offset-indexed metadata index from a .pvar/.bim file.
 //! Reads the file once into a single buffer, builds line offsets, and parses
@@ -242,14 +266,20 @@ VariantMetadataIndex LoadVariantMetadataFromParquet(ClientContext &context, cons
 
 //! Region-pushdown parquet loader — materializes only variants in [pos_start, pos_end]
 //! on the named chrom. Returns a sparse VariantMetadataIndex whose vidx_map keys are
-//! file row numbers (pgenlib-compatible global vidx). total_row_ct must be the total
-//! number of variants in the source file (used to populate idx.variant_ct for
-//! count-mismatch validation). Much faster than loading the full file at biobank scale.
+//! file row numbers (pgenlib-compatible global vidx).
+//!
+//! `variant_ct_hint` sets `idx.variant_ct`. Callers should pass the expected total
+//! (typically `pgfi.raw_variant_ct`) so the downstream count-mismatch check is a
+//! sanity check against pgen — we deliberately do NOT re-scan the full parquet to
+//! count rows, which would defeat the point of pushdown at 170M-variant scale.
 VariantMetadataIndex LoadVariantMetadataFromParquetRegion(ClientContext &context, const string &path,
                                                           const string &chrom, int64_t pos_start, int64_t pos_end,
-                                                          idx_t total_row_ct, const string &func_name);
+                                                          idx_t variant_ct_hint, const string &func_name);
 
-//! Cheap row count via parquet footer metadata.
+//! Row count from a parquet file via row-group metadata aggregation
+//! (DuckDB-optimized `COUNT(*)`). Typically sub-ms but O(num_row_groups),
+//! not literally O(1). Use for count-only metadata paths (psam fast path);
+//! the region-pushdown path avoids this entirely by trusting pgen's count.
 idx_t GetParquetRowCount(ClientContext &context, const string &path);
 
 //! Load sample info from a parquet file via DuckDB's parquet reader.

--- a/src/include/plink_common.hpp
+++ b/src/include/plink_common.hpp
@@ -110,44 +110,84 @@ struct AlignedBuffer {
 // Offset-indexed variant metadata (memory-efficient Scan-time access)
 // ---------------------------------------------------------------------------
 
-//! Offset-indexed variant metadata for memory-efficient Scan-time access.
-//! Stores raw file content in a single buffer and line byte offsets; parses
-//! fields on demand. Thread-safe for concurrent reads (all state is immutable
-//! after construction).
+//! Columnar variant metadata index.
+//!
+//! Two modes:
+//!  * Dense  (vidx_map empty): vectors are indexed directly by file-row vidx.
+//!  * Sparse (vidx_map non-empty): vectors hold a filtered subset; vidx_map
+//!    maps file-row vidx → local index. `variant_ct` still reflects the
+//!    total source row count (for count-mismatch validation), while
+//!    `chroms.size()` is the loaded subset size.
+//!
+//! All accessors take a file-row vidx. Thread-safe for concurrent reads
+//! once construction (or lazy EnsureAlleles/EnsureIds) has completed.
 struct VariantMetadataIndex {
-	//! Raw file content (single allocation)
-	string file_content;
+	//! Columnar typed backing
+	vector<string> chroms;
+	vector<int32_t> positions;
+	vector<string> ids; // "." normalized to "" at load time
+	vector<string> refs;
+	vector<string> alts; // "." normalized to "" at load time
 
-	//! Byte offset of each data line's start within file_content.
-	//! line_offsets[vidx] = byte offset of variant vidx's line.
-	vector<uint64_t> line_offsets;
+	//! Sparse mode: file-row vidx → local index in the vectors. Empty in dense mode.
+	unordered_map<uint32_t, uint32_t> vidx_map;
 
-	//! Whether the source is .bim format (whitespace-delimited, different column order)
-	bool is_bim = false;
+	//! Chromosome offset index for fast region lookups (dense mode only).
+	//! chrom → [first_local_idx, past_end_local_idx). Assumes variants are
+	//! (CHROM, POS)-sorted as required by the PLINK spec.
+	unordered_map<string, std::pair<idx_t, idx_t>> chrom_offsets;
 
-	//! Physical field indices for each logical field (after header parsing)
-	idx_t chrom_idx = 0;
-	idx_t pos_idx = 0;
-	idx_t id_idx = 0;
-	idx_t ref_idx = 0;
-	idx_t alt_idx = 0;
-
-	//! Total variant count
+	//! Total variant count in the source file (not the loaded subset).
 	idx_t variant_ct = 0;
 
-	//! Find the end of line vidx (exclusive, past trailing \r\n)
-	size_t LineEnd(idx_t vidx) const;
+	//! Whether the source was .bim format (affects column-name defaults only).
+	bool is_bim = false;
 
-	//! Extract the N-th delimited field from a line without allocating.
-	//! For .pvar: tab-delimited. For .bim: whitespace-delimited.
-	string GetField(idx_t vidx, idx_t field_idx) const;
+	//! Whether ID/REF/ALT are loaded. Dense text load always sets both true.
+	//! Parquet lazy paths may skip loading these if the query doesn't need them.
+	bool has_ids = true;
+	bool has_alleles = true;
 
-	//! On-demand field access (thread-safe: const on file_content)
-	string GetChrom(idx_t vidx) const;
-	int32_t GetPos(idx_t vidx) const;
-	string GetId(idx_t vidx) const;
-	string GetRef(idx_t vidx) const;
-	string GetAlt(idx_t vidx) const;
+	//! Local index for a file-row vidx.
+	inline idx_t Local(idx_t vidx) const {
+		if (vidx_map.empty()) {
+			return vidx;
+		}
+		auto it = vidx_map.find(static_cast<uint32_t>(vidx));
+		if (it == vidx_map.end()) {
+			throw InternalException("VariantMetadataIndex: vidx %llu not in loaded subset",
+			                        static_cast<unsigned long long>(vidx));
+		}
+		return it->second;
+	}
+
+	//! True iff this index is dense (fully loaded, indexed by vidx directly).
+	inline bool IsDense() const {
+		return vidx_map.empty();
+	}
+
+	//! Returns [first_local_idx, past_end_local_idx) for a chromosome; {0,0} if absent.
+	//! Dense mode only — sparse indexes have been pre-filtered.
+	inline std::pair<idx_t, idx_t> ChromRange(const string &chrom) const {
+		auto it = chrom_offsets.find(chrom);
+		return it == chrom_offsets.end() ? std::make_pair(idx_t {0}, idx_t {0}) : it->second;
+	}
+
+	inline const string &GetChrom(idx_t vidx) const {
+		return chroms[Local(vidx)];
+	}
+	inline int32_t GetPos(idx_t vidx) const {
+		return positions[Local(vidx)];
+	}
+	inline const string &GetId(idx_t vidx) const {
+		return ids[Local(vidx)];
+	}
+	inline const string &GetRef(idx_t vidx) const {
+		return refs[Local(vidx)];
+	}
+	inline const string &GetAlt(idx_t vidx) const {
+		return alts[Local(vidx)];
+	}
 };
 
 //! Build an offset-indexed metadata index from a .pvar/.bim file.
@@ -200,6 +240,18 @@ string FindCompanionFileWithParquet(ClientContext &context, FileSystem &fs, cons
 VariantMetadataIndex LoadVariantMetadataFromParquet(ClientContext &context, const string &path,
                                                     const string &func_name);
 
+//! Region-pushdown parquet loader — materializes only variants in [pos_start, pos_end]
+//! on the named chrom. Returns a sparse VariantMetadataIndex whose vidx_map keys are
+//! file row numbers (pgenlib-compatible global vidx). total_row_ct must be the total
+//! number of variants in the source file (used to populate idx.variant_ct for
+//! count-mismatch validation). Much faster than loading the full file at biobank scale.
+VariantMetadataIndex LoadVariantMetadataFromParquetRegion(ClientContext &context, const string &path,
+                                                          const string &chrom, int64_t pos_start, int64_t pos_end,
+                                                          idx_t total_row_ct, const string &func_name);
+
+//! Cheap row count via parquet footer metadata.
+idx_t GetParquetRowCount(ClientContext &context, const string &path);
+
 //! Load sample info from a parquet file via DuckDB's parquet reader.
 SampleInfo LoadSampleInfoFromParquet(ClientContext &context, const string &path);
 
@@ -220,6 +272,14 @@ VariantMetadataIndex LoadVariantMetadata(ClientContext &context, const string &p
 
 //! Load sample info, auto-dispatching between parquet, native text, and arbitrary sources.
 SampleInfo LoadSampleMetadata(ClientContext &context, const string &path);
+
+//! Cheap count-only psam loader: returns SampleInfo with `sample_ct` set but
+//! `iids`/`fids`/`iid_to_idx` empty. For parquet, uses footer metadata (O(1)).
+//! For text/source, falls back to full load and discards strings to keep memory low.
+//! Use when the query doesn't need IID strings (no VARCHAR sample filter, no
+//! genotypes:='columns'/'struct', not orient='genotype'/'sample'). At biobank
+//! scale this saves the ~600ms columnar string copy of 7M IIDs.
+SampleInfo LoadSampleCount(ClientContext &context, const string &path);
 
 // ---------------------------------------------------------------------------
 // Sample subsetting (for PgrGetCounts / PgrGet)

--- a/src/include/plink_profile.hpp
+++ b/src/include/plink_profile.hpp
@@ -1,0 +1,64 @@
+#pragma once
+
+// Bind-phase timing probes, gated on the PLINKING_BIND_PROFILE env var.
+// Header-only to avoid touching the build. Emits to stderr so output is
+// captured even when an exception unwinds the bind call.
+
+#include <chrono>
+#include <cstdarg>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+
+namespace duckdb {
+
+inline bool BindProfileEnabled() {
+	static int cached = -1;
+	if (cached == -1) {
+		const char *v = std::getenv("PLINKING_BIND_PROFILE");
+		cached = (v && v[0] && std::strcmp(v, "0") != 0) ? 1 : 0;
+	}
+	return cached == 1;
+}
+
+struct BindPhaseTimer {
+	using Clock = std::chrono::steady_clock;
+	std::string label;
+	Clock::time_point start;
+	bool active;
+
+	explicit BindPhaseTimer(std::string lbl) : label(std::move(lbl)), active(BindProfileEnabled()) {
+		if (active) {
+			start = Clock::now();
+			std::fprintf(stderr, "[BIND_PROFILE] ENTER %s\n", label.c_str());
+			std::fflush(stderr);
+		}
+	}
+
+	void Note(const char *fmt, ...) {
+		if (!active) {
+			return;
+		}
+		auto now = Clock::now();
+		auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(now - start).count();
+		std::fprintf(stderr, "[BIND_PROFILE]   %s @ %lldms: ", label.c_str(), static_cast<long long>(ms));
+		va_list args;
+		va_start(args, fmt);
+		std::vfprintf(stderr, fmt, args);
+		va_end(args);
+		std::fprintf(stderr, "\n");
+		std::fflush(stderr);
+	}
+
+	~BindPhaseTimer() {
+		if (active) {
+			auto now = Clock::now();
+			auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(now - start).count();
+			std::fprintf(stderr, "[BIND_PROFILE] LEAVE %s: %lldms\n", label.c_str(), static_cast<long long>(ms));
+			std::fflush(stderr);
+		}
+	}
+};
+
+} // namespace duckdb

--- a/src/include/psam_reader.hpp
+++ b/src/include/psam_reader.hpp
@@ -14,13 +14,26 @@ namespace duckdb {
 // ---------------------------------------------------------------------------
 
 //! Sample metadata extracted from .psam or .fam files.
-//! Used by read_psam for its own output and by read_pgen to look up sample
-//! information without re-parsing the file.
+//!
+//! At biobank scale (~7M samples), the iid_to_idx map is expensive to build
+//! (string hashing + allocations) and most queries do not need it (integer
+//! sample filters, or no sample filter at all). So iid_to_idx is **lazy**:
+//! call EnsureIidMap() before using it. Callers that do not need IID-based
+//! lookups never pay the cost.
+//!
+//! Similarly, `iids` may be empty when sample_ct is loaded from parquet
+//! metadata alone (cheap constant-time call). Callers that need the IID
+//! strings (for column names, VARCHAR lookups, etc.) must ensure iids is
+//! populated before access.
 struct SampleInfo {
-	vector<string> iids;                     //!< Individual IDs in file order
+	vector<string> iids;                     //!< Individual IDs in file order (possibly lazy)
 	vector<string> fids;                     //!< Family IDs (empty if no FID column)
-	idx_t sample_ct;                         //!< Total sample count
-	unordered_map<string, idx_t> iid_to_idx; //!< IID → file-order index
+	idx_t sample_ct;                         //!< Total sample count (always populated)
+	unordered_map<string, idx_t> iid_to_idx; //!< IID → file-order index (lazy; call EnsureIidMap)
+
+	//! Build iid_to_idx from iids. Validates uniqueness. Safe to call multiple times.
+	//! Throws if duplicate IIDs are found. Requires iids to be populated.
+	void EnsureIidMap(const string &source_label = "sample file");
 };
 
 //! Parse a .psam or .fam file and return sample metadata.

--- a/src/pfile_reader.cpp
+++ b/src/pfile_reader.cpp
@@ -1,5 +1,6 @@
 #include "pfile_reader.hpp"
 #include "plink_common.hpp"
+#include "plink_profile.hpp"
 #include "pvar_reader.hpp"
 #include "psam_reader.hpp"
 
@@ -159,16 +160,11 @@ static PfileSampleMetadata LoadPfileSampleMetadataFromSource(ClientContext &cont
 				fields.push_back(val.IsNull() ? "" : val.ToString());
 			}
 
-			// Extract sample info
-			const auto &iid = fields[iid_idx];
-			if (sample_info_out.iid_to_idx.count(iid)) {
-				throw IOException("read_pfile: source '%s' has duplicate IID '%s'", source, iid);
-			}
-			sample_info_out.iids.push_back(iid);
+			// iid_to_idx is lazy (see SampleInfo::EnsureIidMap).
+			sample_info_out.iids.push_back(fields[iid_idx]);
 			if (has_fid) {
 				sample_info_out.fids.push_back(fields[fid_idx]);
 			}
-			sample_info_out.iid_to_idx[iid] = sample_info_out.iids.size() - 1;
 
 			meta.rows.push_back(std::move(fields));
 		}
@@ -243,18 +239,12 @@ static PfileSampleMetadata LoadPfileSampleMetadata(ClientContext &context, const
 			fields = SplitTabLine(line);
 		}
 
-		// Extract sample info for IID lookups
+		// iid_to_idx is built lazily on demand (see SampleInfo::EnsureIidMap).
 		if (iid_idx < fields.size()) {
-			const auto &iid = fields[iid_idx];
-			if (sample_info_out.iid_to_idx.count(iid)) {
-				throw IOException("read_pfile: file '%s' line %llu has duplicate IID '%s'", path,
-				                  static_cast<unsigned long long>(i + 1), iid);
-			}
-			sample_info_out.iids.push_back(iid);
+			sample_info_out.iids.push_back(fields[iid_idx]);
 			if (has_fid && fid_idx < fields.size()) {
 				sample_info_out.fids.push_back(fields[fid_idx]);
 			}
-			sample_info_out.iid_to_idx[iid] = sample_info_out.iids.size() - 1;
 		}
 
 		meta.rows.push_back(std::move(fields));
@@ -453,6 +443,7 @@ struct PfileLocalState : public LocalTableFunctionState {
 
 static unique_ptr<FunctionData> PfileBind(ClientContext &context, TableFunctionBindInput &input,
                                           vector<LogicalType> &return_types, vector<string> &names) {
+	BindPhaseTimer bind_timer("PfileBind(total)");
 	auto bind_data = make_uniq<PfileBindData>();
 
 	// --- Resolve file paths ---
@@ -554,6 +545,7 @@ static unique_ptr<FunctionData> PfileBind(ClientContext &context, TableFunctionB
 	}
 
 	// --- Initialize pgenlib (Phase 1) to get counts ---
+	bind_timer.Note("file paths resolved, starting pgenlib init");
 	plink2::PgenFileInfo pgfi;
 	plink2::PreinitPgfi(&pgfi);
 
@@ -593,7 +585,21 @@ static unique_ptr<FunctionData> PfileBind(ClientContext &context, TableFunctionB
 	}
 
 	// --- Load variant metadata ---
-	bind_data->variants = LoadVariantMetadata(context, bind_data->pvar_path, "read_pfile");
+	bind_timer.Note("pgenlib init done (raw_variant_ct=%u, raw_sample_ct=%u), loading variant metadata",
+	                bind_data->raw_variant_ct, bind_data->raw_sample_ct);
+	// Parquet + region: push the WHERE into the parquet scan so we only materialize
+	// the region's variants instead of all N (huge win at 170M).
+	if (bind_data->region.active && IsParquetFile(bind_data->pvar_path)) {
+		idx_t total_ct = GetParquetRowCount(context, bind_data->pvar_path);
+		bind_data->variants = LoadVariantMetadataFromParquetRegion(context, bind_data->pvar_path,
+		                                                           bind_data->region.chrom, bind_data->region.start,
+		                                                           bind_data->region.end, total_ct, "read_pfile");
+	} else {
+		bind_data->variants = LoadVariantMetadata(context, bind_data->pvar_path, "read_pfile");
+	}
+	bind_timer.Note("variant metadata loaded (%llu total variants, %llu loaded)",
+	                (unsigned long long)bind_data->variants.variant_ct,
+	                (unsigned long long)bind_data->variants.chroms.size());
 
 	if (bind_data->variants.variant_ct != bind_data->raw_variant_ct) {
 		throw InvalidInputException("read_pfile: variant count mismatch: .pgen has %u variants, "
@@ -603,13 +609,46 @@ static unique_ptr<FunctionData> PfileBind(ClientContext &context, TableFunctionB
 	}
 
 	// --- Load sample info ---
-	// In genotype/sample orient modes, LoadPfileSampleMetadata populates both
-	// sample_info and sample_metadata from a single file read. Otherwise, use LoadSampleInfo.
+	// Determine whether the query actually needs IID strings. If not, we only
+	// need the row count — at biobank scale this saves ~600ms of string copies.
+	// Need IIDs when:
+	//   * orient = genotype/sample (full per-sample metadata)
+	//   * samples filter contains VARCHAR (IID-string lookup)
+	//   * genotypes := 'columns' or 'struct' in variant orient (column names from IIDs)
+	bool needs_iids = false;
+	if (bind_data->orient_mode == OrientMode::GENOTYPE || bind_data->orient_mode == OrientMode::SAMPLE) {
+		needs_iids = true;
+	}
+	{
+		auto it = input.named_parameters.find("samples");
+		if (it != input.named_parameters.end()) {
+			auto &child_type = ListType::GetChildType(it->second.type());
+			if (child_type.id() == LogicalTypeId::VARCHAR) {
+				needs_iids = true;
+			}
+		}
+	}
+	{
+		auto it = input.named_parameters.find("genotypes");
+		if (it != input.named_parameters.end() && bind_data->orient_mode == OrientMode::VARIANT) {
+			auto gv = StringUtil::Lower(it->second.GetValue<string>());
+			if (gv == "columns" || gv == "struct") {
+				needs_iids = true;
+			}
+		}
+	}
+
+	bind_timer.Note("loading sample metadata (needs_iids=%s)", needs_iids ? "yes" : "no");
 	if (bind_data->orient_mode == OrientMode::GENOTYPE || bind_data->orient_mode == OrientMode::SAMPLE) {
 		bind_data->sample_metadata = LoadPfileSampleMetadata(context, bind_data->psam_path, bind_data->sample_info);
-	} else {
+	} else if (needs_iids) {
 		bind_data->sample_info = LoadSampleMetadata(context, bind_data->psam_path);
+	} else {
+		bind_data->sample_info = LoadSampleCount(context, bind_data->psam_path);
 	}
+	bind_timer.Note("sample metadata loaded (%llu samples, iids=%llu)",
+	                (unsigned long long)bind_data->sample_info.sample_ct,
+	                (unsigned long long)bind_data->sample_info.iids.size());
 
 	if (bind_data->sample_info.sample_ct != bind_data->raw_sample_ct) {
 		throw InvalidInputException("read_pfile: sample count mismatch: .pgen has %u samples, "
@@ -640,6 +679,8 @@ static unique_ptr<FunctionData> PfileBind(ClientContext &context, TableFunctionB
 				bind_data->sample_indices.push_back(static_cast<uint32_t>(idx));
 			}
 		} else if (child_type.id() == LogicalTypeId::VARCHAR) {
+			// Lazily build iid_to_idx only when VARCHAR filter is actually used.
+			bind_data->sample_info.EnsureIidMap("read_pfile: " + bind_data->psam_path);
 			auto &children = ListValue::GetChildren(samples_val);
 			for (auto &child : children) {
 				auto iid = child.GetValue<string>();
@@ -682,8 +723,8 @@ static unique_ptr<FunctionData> PfileBind(ClientContext &context, TableFunctionB
 	}
 
 	// --- Build effective variant list (intersection of region + variant filter) ---
+	bind_timer.Note("building effective variant list");
 	{
-		// Start with all variants if no filter, or variant_indices if variant filter active
 		std::unordered_set<uint32_t> variant_set;
 		bool use_variant_set = bind_data->has_variant_filter;
 		if (use_variant_set) {
@@ -695,26 +736,83 @@ static unique_ptr<FunctionData> PfileBind(ClientContext &context, TableFunctionB
 		bool any_filter_active = bind_data->region.active || bind_data->has_variant_filter;
 
 		if (any_filter_active) {
+			BindPhaseTimer evl_timer("effective-variant-list-scan");
 			bind_data->has_effective_variant_list = true;
 
-			for (uint32_t vidx = 0; vidx < bind_data->raw_variant_ct; vidx++) {
-				// Check region filter
-				if (bind_data->region.active) {
-					if (bind_data->variants.GetChrom(vidx) != bind_data->region.chrom) {
+			// Case A: sparse pvar index (parquet region pushdown). The loaded
+			// subset IS the region-matched set; iterate vidx_map keys directly.
+			if (!bind_data->variants.vidx_map.empty()) {
+				bind_data->effective_variant_indices.reserve(bind_data->variants.vidx_map.size());
+				for (auto &kv : bind_data->variants.vidx_map) {
+					if (use_variant_set && variant_set.find(kv.first) == variant_set.end()) {
 						continue;
 					}
-					int64_t pos = bind_data->variants.GetPos(vidx);
-					if (pos < bind_data->region.start || pos > bind_data->region.end) {
-						continue;
+					bind_data->effective_variant_indices.push_back(kv.first);
+				}
+				std::sort(bind_data->effective_variant_indices.begin(), bind_data->effective_variant_indices.end());
+				evl_timer.Note("sparse pvar: %llu region variants pre-filtered; %llu passed",
+				               (unsigned long long)bind_data->variants.vidx_map.size(),
+				               (unsigned long long)bind_data->effective_variant_indices.size());
+			} else if (bind_data->region.active && !bind_data->variants.chrom_offsets.empty()) {
+				// Case B: dense + region + chrom_offsets → O(log N) binary-search bounds.
+				auto it = bind_data->variants.chrom_offsets.find(bind_data->region.chrom);
+				if (it != bind_data->variants.chrom_offsets.end()) {
+					idx_t lo_local = it->second.first;
+					idx_t hi_local = it->second.second;
+					auto &positions = bind_data->variants.positions;
+					// binary search for pos >= region.start
+					idx_t lo = lo_local, hi = hi_local;
+					while (lo < hi) {
+						idx_t mid = lo + (hi - lo) / 2;
+						if (positions[mid] < bind_data->region.start) {
+							lo = mid + 1;
+						} else {
+							hi = mid;
+						}
+					}
+					idx_t start_idx = lo;
+					// binary search for pos > region.end
+					lo = lo_local;
+					hi = hi_local;
+					while (lo < hi) {
+						idx_t mid = lo + (hi - lo) / 2;
+						if (positions[mid] <= bind_data->region.end) {
+							lo = mid + 1;
+						} else {
+							hi = mid;
+						}
+					}
+					idx_t end_idx = lo;
+					bind_data->effective_variant_indices.reserve(end_idx - start_idx);
+					for (idx_t vidx = start_idx; vidx < end_idx; vidx++) {
+						if (use_variant_set && variant_set.find(static_cast<uint32_t>(vidx)) == variant_set.end()) {
+							continue;
+						}
+						bind_data->effective_variant_indices.push_back(static_cast<uint32_t>(vidx));
 					}
 				}
-
-				// Check variant filter
-				if (use_variant_set && variant_set.find(vidx) == variant_set.end()) {
-					continue;
+				evl_timer.Note("dense+region: chrom_offsets+bsearch → %llu passed",
+				               (unsigned long long)bind_data->effective_variant_indices.size());
+			} else {
+				// Case C: variant filter only (no region), or region without chrom_offsets.
+				// Full scan with cheap columnar access.
+				for (uint32_t vidx = 0; vidx < bind_data->raw_variant_ct; vidx++) {
+					if (bind_data->region.active) {
+						if (bind_data->variants.GetChrom(vidx) != bind_data->region.chrom) {
+							continue;
+						}
+						int64_t pos = bind_data->variants.GetPos(vidx);
+						if (pos < bind_data->region.start || pos > bind_data->region.end) {
+							continue;
+						}
+					}
+					if (use_variant_set && variant_set.find(vidx) == variant_set.end()) {
+						continue;
+					}
+					bind_data->effective_variant_indices.push_back(vidx);
 				}
-
-				bind_data->effective_variant_indices.push_back(vidx);
+				evl_timer.Note("linear fallback: %u variants scanned, %llu passed", bind_data->raw_variant_ct,
+				               (unsigned long long)bind_data->effective_variant_indices.size());
 			}
 		}
 	}

--- a/src/pfile_reader.cpp
+++ b/src/pfile_reader.cpp
@@ -588,12 +588,14 @@ static unique_ptr<FunctionData> PfileBind(ClientContext &context, TableFunctionB
 	bind_timer.Note("pgenlib init done (raw_variant_ct=%u, raw_sample_ct=%u), loading variant metadata",
 	                bind_data->raw_variant_ct, bind_data->raw_sample_ct);
 	// Parquet + region: push the WHERE into the parquet scan so we only materialize
-	// the region's variants instead of all N (huge win at 170M).
+	// the region's variants instead of all N (huge win at 170M). Pass pgen's
+	// raw_variant_ct as the hint so the loader doesn't re-scan the file for
+	// a row count — the post-load check becomes a sanity check against pgen
+	// rather than a second full-file open.
 	if (bind_data->region.active && IsParquetFile(bind_data->pvar_path)) {
-		idx_t total_ct = GetParquetRowCount(context, bind_data->pvar_path);
-		bind_data->variants = LoadVariantMetadataFromParquetRegion(context, bind_data->pvar_path,
-		                                                           bind_data->region.chrom, bind_data->region.start,
-		                                                           bind_data->region.end, total_ct, "read_pfile");
+		bind_data->variants = LoadVariantMetadataFromParquetRegion(
+		    context, bind_data->pvar_path, bind_data->region.chrom, bind_data->region.start, bind_data->region.end,
+		    static_cast<idx_t>(bind_data->raw_variant_ct), "read_pfile");
 	} else {
 		bind_data->variants = LoadVariantMetadata(context, bind_data->pvar_path, "read_pfile");
 	}

--- a/src/plink_common.cpp
+++ b/src/plink_common.cpp
@@ -95,8 +95,12 @@ OrientMode ResolveOrientMode(const string &orient_str, const string &func_name) 
 // Columnar load helpers (shared between parquet and text paths)
 // ---------------------------------------------------------------------------
 
-//! Build chrom_offsets from the chroms column. Assumes (CHROM, POS)-sorted input.
-static void BuildChromOffsets(VariantMetadataIndex &idx) {
+//! Build chrom_offsets from the chroms column. Requires (CHROM, POS)-sorted
+//! input (PLINK spec). Detects non-contiguous chroms (a spec violation that
+//! generic sources like SQL views might produce) and throws rather than
+//! silently dropping runs. The rest of the code (binary search on POS) assumes
+//! contiguous runs, so this is a hard precondition.
+static void BuildChromOffsets(VariantMetadataIndex &idx, const string &source_label) {
 	idx.chrom_offsets.clear();
 	if (idx.chroms.empty()) {
 		return;
@@ -105,12 +109,25 @@ static void BuildChromOffsets(VariantMetadataIndex &idx) {
 	const string *current = &idx.chroms[0];
 	for (idx_t i = 1; i < idx.chroms.size(); i++) {
 		if (idx.chroms[i] != *current) {
-			idx.chrom_offsets.emplace(*current, std::make_pair(run_start, i));
+			auto inserted = idx.chrom_offsets.emplace(*current, std::make_pair(run_start, i));
+			if (!inserted.second) {
+				throw InvalidInputException("%s: chromosome '%s' appears in non-contiguous runs (variants must be "
+				                            "sorted by (CHROM, POS) as required by the PLINK spec; first run ended at "
+				                            "row %llu, found again at row %llu)",
+				                            source_label, current->c_str(),
+				                            static_cast<unsigned long long>(inserted.first->second.second),
+				                            static_cast<unsigned long long>(i));
+			}
 			current = &idx.chroms[i];
 			run_start = i;
 		}
 	}
-	idx.chrom_offsets.emplace(*current, std::make_pair(run_start, idx.chroms.size()));
+	auto inserted = idx.chrom_offsets.emplace(*current, std::make_pair(run_start, idx.chroms.size()));
+	if (!inserted.second) {
+		throw InvalidInputException(
+		    "%s: chromosome '%s' appears in non-contiguous runs (variants must be sorted by (CHROM, POS))",
+		    source_label, current->c_str());
+	}
 }
 
 //! Parse a single delimited field from [start, end) in buf (no allocation).
@@ -275,12 +292,16 @@ VariantMetadataIndex LoadVariantMetadataIndex(ClientContext &context, const stri
 		size_t fstart = 0, flen = 0;
 		string chrom, id, ref, alt;
 		int32_t pos_val = 0;
+		// Track whether each required field was parsed (rather than left at default).
+		// Prevents silent data corruption on truncated/malformed lines.
+		bool got_chrom = false, got_pos = false, got_id = false, got_ref = false, got_alt = false;
 		for (idx_t f = 0; f <= max_field; f++) {
 			if (!NextField(buf, content_end, &cursor, &fstart, &flen, whitespace)) {
 				break;
 			}
 			if (f == chrom_field) {
 				chrom.assign(buf + fstart, flen);
+				got_chrom = true;
 			} else if (f == pos_field) {
 				// strtol on a non-nul-terminated span: copy into small local
 				char tmp[32];
@@ -295,21 +316,44 @@ VariantMetadataIndex LoadVariantMetadataIndex(ClientContext &context, const stri
 					                            static_cast<unsigned long long>(pos));
 				}
 				pos_val = static_cast<int32_t>(v);
+				got_pos = true;
 			} else if (f == id_field) {
 				if (flen == 1 && buf[fstart] == '.') {
 					// empty
 				} else {
 					id.assign(buf + fstart, flen);
 				}
+				got_id = true;
 			} else if (f == ref_field) {
 				ref.assign(buf + fstart, flen);
+				got_ref = true;
 			} else if (f == alt_field) {
 				if (flen == 1 && buf[fstart] == '.') {
 					// empty
 				} else {
 					alt.assign(buf + fstart, flen);
 				}
+				got_alt = true;
 			}
+		}
+
+		// Reject truncated/malformed lines (missing required columns) instead of
+		// silently pushing default-initialized values.
+		if (!got_chrom || !got_pos || !got_id || !got_ref || !got_alt) {
+			string missing;
+			if (!got_chrom)
+				missing += " CHROM";
+			if (!got_pos)
+				missing += " POS";
+			if (!got_id)
+				missing += " ID";
+			if (!got_ref)
+				missing += " REF";
+			if (!got_alt)
+				missing += " ALT";
+			throw InvalidInputException(
+			    "%s: .pvar/.bim file '%s' has a line missing required fields [%s] at byte offset %llu", func_name, path,
+			    missing.c_str(), static_cast<unsigned long long>(pos));
 		}
 
 		idx.chroms.emplace_back(std::move(chrom));
@@ -324,7 +368,7 @@ VariantMetadataIndex LoadVariantMetadataIndex(ClientContext &context, const stri
 	idx.variant_ct = idx.chroms.size();
 	idx.has_ids = true;
 	idx.has_alleles = true;
-	BuildChromOffsets(idx);
+	BuildChromOffsets(idx, path);
 	return idx;
 }
 
@@ -652,19 +696,27 @@ static void IngestVariantResult(QueryResult &result, const string &source_label,
 			}
 		}
 
-		// file_row_number → sparse vidx_map
+		// file_row_number → sparse vidx_map + local_to_vidx reverse map.
+		// Both are populated so callers iterating the loaded subset can map
+		// local → vidx in O(1) (e.g. ResolveByCpra, BuildVariantIdIndex).
 		if (rn_col != DConstants::INVALID_INDEX) {
 			auto &vec = chunk->data[rn_col];
 			UnifiedVectorFormat uvf;
 			vec.ToUnifiedFormat(n, uvf);
 			auto data = reinterpret_cast<const int64_t *>(uvf.data);
 			idx_t local_base = idx.chroms.size() - n;
+			if (idx.local_to_vidx.size() < idx.chroms.size()) {
+				idx.local_to_vidx.resize(idx.chroms.size());
+			}
 			for (idx_t i = 0; i < n; i++) {
 				auto si = uvf.sel->get_index(i);
 				if (!uvf.validity.RowIsValid(si)) {
 					throw IOException("%s: NULL file_row_number encountered (internal error)", func_name);
 				}
-				idx.vidx_map.emplace(static_cast<uint32_t>(data[si]), static_cast<uint32_t>(local_base + i));
+				uint32_t vidx = static_cast<uint32_t>(data[si]);
+				uint32_t local = static_cast<uint32_t>(local_base + i);
+				idx.vidx_map.emplace(vidx, local);
+				idx.local_to_vidx[local] = vidx;
 			}
 		}
 	}
@@ -689,47 +741,82 @@ VariantMetadataIndex LoadVariantMetadataFromParquet(ClientContext &context, cons
 	idx.has_ids = true;
 	idx.has_alleles = true;
 	timer.Note("ingested %llu variants", (unsigned long long)idx.variant_ct);
-	BuildChromOffsets(idx);
+	BuildChromOffsets(idx, path);
 	timer.Note("built chrom_offsets (%llu chroms)", (unsigned long long)idx.chrom_offsets.size());
 	return idx;
+}
+
+//! Pick the chromosome column name. Different pvar producers use either
+//! "#CHROM" (plink2 native) or "CHROM" (custom exports). Introspecting via
+//! a LIMIT 0 scan is cheaper than a wrapped DESCRIBE: DuckDB only reads the
+//! parquet footer to get schema, no row groups touched.
+static string DetectChromColumn(Connection &conn, const string &path, const string &func_name) {
+	auto escaped_path = StringUtil::Replace(path, "'", "''");
+	auto result = conn.Query("SELECT * FROM read_parquet('" + escaped_path + "') LIMIT 0");
+	if (result->HasError()) {
+		throw IOException("%s: failed to read parquet schema for '%s': %s", func_name, path, result->GetError());
+	}
+	for (auto &name : result->names) {
+		auto lower = StringUtil::Lower(name);
+		if (lower == "#chrom") {
+			return "#CHROM";
+		}
+	}
+	for (auto &name : result->names) {
+		auto lower = StringUtil::Lower(name);
+		if (lower == "chrom") {
+			return "CHROM";
+		}
+	}
+	throw InvalidInputException("%s: parquet companion '%s' has no CHROM or #CHROM column (columns: %s)", func_name,
+	                            path, StringUtil::Join(result->names, ", "));
 }
 
 //! Region-pushdown loader: queries the parquet file with a WHERE clause so
 //! only matching rows are materialized. Returns a sparse index whose
 //! vidx_map keys are the file row numbers (pgenlib-compatible vidx).
-//! total_row_ct lets caller set variant_ct correctly for count validation.
+//!
+//! `variant_ct_hint` — the caller's expected total row count (typically
+//! `pgfi.raw_variant_ct` from the pgen header). Used as `idx.variant_ct` so
+//! the downstream count-mismatch check is effectively a sanity check against
+//! pgen (we don't re-scan the full parquet to count rows; trusting pgen keeps
+//! the region path O(region size), not O(file size)).
 VariantMetadataIndex LoadVariantMetadataFromParquetRegion(ClientContext &context, const string &path,
                                                           const string &chrom, int64_t pos_start, int64_t pos_end,
-                                                          idx_t total_row_ct, const string &func_name) {
+                                                          idx_t variant_ct_hint, const string &func_name) {
 	BindPhaseTimer timer("LoadVariantMetadataFromParquetRegion");
 	auto &db = DatabaseInstance::GetDatabase(context);
 	Connection conn(db);
-	auto escaped_path = StringUtil::Replace(path, "'", "''");
-	auto escaped_chrom = StringUtil::Replace(chrom, "'", "''");
 
-	// file_row_number gives pgenlib-compatible global vidx; stats pruning + column
-	// projection keep this O(region_size), not O(total).
-	string sql = "SELECT \"#CHROM\" AS \"#CHROM\", POS, ID, REF, ALT, file_row_number "
+	// Determine whether the file uses "#CHROM" or "CHROM" for its chrom column.
+	// Introspecting the schema upfront avoids the old error-driven retry that
+	// could mask POS-type or other schema errors as column-name failures.
+	auto chrom_col_name = DetectChromColumn(conn, path, func_name);
+	timer.Note("chrom column: %s", chrom_col_name.c_str());
+
+	// file_row_number gives pgenlib-compatible global vidx. stats pruning +
+	// column projection keep this O(region_size), not O(total).
+	//
+	// Path is embedded via quote-doubling (DuckDB follows SQL-standard string
+	// literals — no backslash escapes — so `''` is sufficient). The user-
+	// controlled chrom and position values use prepared-statement parameters.
+	auto escaped_path = StringUtil::Replace(path, "'", "''");
+	string sql = "SELECT \"" + chrom_col_name +
+	             "\" AS \"#CHROM\", POS, ID, REF, ALT, file_row_number " //
 	             "FROM read_parquet('" +
 	             escaped_path +
-	             "', file_row_number=true) "
-	             "WHERE (CAST(\"#CHROM\" AS VARCHAR) = '" +
-	             escaped_chrom + "') AND POS BETWEEN " + std::to_string(pos_start) + " AND " + std::to_string(pos_end) +
-	             " ORDER BY file_row_number";
-	auto result = conn.Query(sql);
+	             "', file_row_number=true) " //
+	             "WHERE (CAST(\"" +
+	             chrom_col_name +
+	             "\" AS VARCHAR) = $1) AND POS BETWEEN $2 AND $3 " //
+	             "ORDER BY file_row_number";
+	auto pstmt = conn.Prepare(sql);
+	if (pstmt->HasError()) {
+		throw IOException("%s: region-pushdown prepare failed on '%s': %s", func_name, path, pstmt->GetError());
+	}
+	auto result = pstmt->Execute(chrom, pos_start, pos_end);
 	if (result->HasError()) {
-		// Retry without `#` prefix column alias if the file uses "CHROM" (alias still selects by position)
-		auto alt_sql = "SELECT CHROM AS \"#CHROM\", POS, ID, REF, ALT, file_row_number "
-		               "FROM read_parquet('" +
-		               escaped_path +
-		               "', file_row_number=true) "
-		               "WHERE (CAST(CHROM AS VARCHAR) = '" +
-		               escaped_chrom + "') AND POS BETWEEN " + std::to_string(pos_start) + " AND " +
-		               std::to_string(pos_end) + " ORDER BY file_row_number";
-		result = conn.Query(alt_sql);
-		if (result->HasError()) {
-			throw IOException("%s: region-pushdown query failed on '%s': %s", func_name, path, result->GetError());
-		}
+		throw IOException("%s: region-pushdown query failed on '%s': %s", func_name, path, result->GetError());
 	}
 	timer.Note("pushdown query returned");
 
@@ -737,19 +824,31 @@ VariantMetadataIndex LoadVariantMetadataFromParquetRegion(ClientContext &context
 	idx.is_bim = false;
 	string label = "parquet companion '" + path + "' (region pushdown)";
 	IngestVariantResult(*result, label, func_name, idx);
-	idx.variant_ct = total_row_ct; // total from parquet metadata (for count-mismatch validation)
+	// variant_ct = caller's hint (typically pgen's raw_variant_ct). The post-load
+	// count-mismatch check in the caller becomes a sanity check against pgen;
+	// we don't open the parquet file a second time to count rows.
+	idx.variant_ct = variant_ct_hint;
 	idx.has_ids = true;
 	idx.has_alleles = true;
 	// Single chrom in pushdown, single contiguous range of local indices
 	if (!idx.chroms.empty()) {
 		idx.chrom_offsets.emplace(idx.chroms.front(), std::make_pair(idx_t {0}, idx.chroms.size()));
 	}
-	timer.Note("ingested %llu region variants (total_ct=%llu)", (unsigned long long)idx.chroms.size(),
-	           (unsigned long long)total_row_ct);
+	timer.Note("ingested %llu region variants (variant_ct hint=%llu)", (unsigned long long)idx.chroms.size(),
+	           (unsigned long long)variant_ct_hint);
 	return idx;
 }
 
-//! Get total row count from a parquet file via its footer metadata (no row scan).
+//! Get total row count from a parquet file.
+//!
+//! Uses `SELECT COUNT(*) FROM read_parquet(...)`, which DuckDB optimizes to
+//! read row-group `num_rows` from the footer — O(num_row_groups), not a
+//! full scan. At biobank scale this is sub-millisecond (7M rows completed
+//! in <1ms in our profiling), but it is NOT literally O(1): files with
+//! many tiny row groups pay proportionally more. Use only for paths where
+//! the whole file hasn't already been opened (e.g. count-only psam mode).
+//! The region-pushdown path explicitly avoids this by trusting pgen's
+//! raw_variant_ct as the variant_ct.
 idx_t GetParquetRowCount(ClientContext &context, const string &path) {
 	auto &db = DatabaseInstance::GetDatabase(context);
 	Connection conn(db);
@@ -875,7 +974,7 @@ VariantMetadataIndex LoadVariantMetadataFromSource(ClientContext &context, const
 	idx.variant_ct = idx.chroms.size();
 	idx.has_ids = true;
 	idx.has_alleles = true;
-	BuildChromOffsets(idx);
+	BuildChromOffsets(idx, source);
 	return idx;
 }
 
@@ -1310,13 +1409,17 @@ static void ValidateVariantIndex(int64_t idx, uint32_t raw_variant_ct, const str
 	}
 }
 
-//! Build a map from variant ID to 0-based index.
-static unordered_map<string, uint32_t> BuildVariantIdIndex(const VariantMetadataIndex &variants) {
+unordered_map<string, uint32_t> BuildVariantIdIndex(const VariantMetadataIndex &variants) {
+	// Iterate the loaded subset (dense or sparse) by local index. In sparse mode
+	// the local slot's file-row vidx comes from local_to_vidx; in dense mode
+	// local == vidx. Using variant_ct to bound the loop is WRONG for sparse
+	// indexes (where variant_ct is the full source count, not the loaded size).
 	unordered_map<string, uint32_t> id_to_idx;
-	for (idx_t i = 0; i < variants.variant_ct; i++) {
-		auto id = variants.GetId(i);
+	id_to_idx.reserve(variants.chroms.size());
+	for (idx_t local = 0; local < variants.chroms.size(); local++) {
+		const auto &id = variants.ids[local];
 		if (!id.empty()) {
-			id_to_idx[id] = static_cast<uint32_t>(i);
+			id_to_idx[id] = variants.VidxForLocal(local);
 		}
 	}
 	return id_to_idx;
@@ -1355,29 +1458,10 @@ static uint32_t ResolveByCpra(const VariantMetadataIndex &variants, const string
 		}
 		if (ref_match && alt_match) {
 			if (variants.refs[i] == *ref_match && variants.alts[i] == *alt_match) {
-				// Map local idx back to file-row vidx
-				if (!variants.vidx_map.empty()) {
-					for (auto &kv : variants.vidx_map) {
-						if (kv.second == i) {
-							return kv.first;
-						}
-					}
-					throw InternalException("ResolveByCpra: local idx %llu missing from vidx_map",
-					                        static_cast<unsigned long long>(i));
-				}
-				return static_cast<uint32_t>(i);
+				return variants.VidxForLocal(i);
 			}
 		} else {
-			if (!variants.vidx_map.empty()) {
-				for (auto &kv : variants.vidx_map) {
-					if (kv.second == i) {
-						return kv.first;
-					}
-				}
-				throw InternalException("ResolveByCpra: local idx %llu missing from vidx_map",
-				                        static_cast<unsigned long long>(i));
-			}
-			return static_cast<uint32_t>(i);
+			return variants.VidxForLocal(i);
 		}
 	}
 

--- a/src/plink_common.cpp
+++ b/src/plink_common.cpp
@@ -1,4 +1,5 @@
 #include "plink_common.hpp"
+#include "plink_profile.hpp"
 
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/common/types/vector.hpp"
@@ -90,135 +91,94 @@ OrientMode ResolveOrientMode(const string &orient_str, const string &func_name) 
 // Offset-indexed variant metadata
 // ---------------------------------------------------------------------------
 
-size_t VariantMetadataIndex::LineEnd(idx_t vidx) const {
-	size_t end;
-	if (vidx + 1 < variant_ct) {
-		end = static_cast<size_t>(line_offsets[vidx + 1]);
+// ---------------------------------------------------------------------------
+// Columnar load helpers (shared between parquet and text paths)
+// ---------------------------------------------------------------------------
+
+//! Build chrom_offsets from the chroms column. Assumes (CHROM, POS)-sorted input.
+static void BuildChromOffsets(VariantMetadataIndex &idx) {
+	idx.chrom_offsets.clear();
+	if (idx.chroms.empty()) {
+		return;
+	}
+	idx_t run_start = 0;
+	const string *current = &idx.chroms[0];
+	for (idx_t i = 1; i < idx.chroms.size(); i++) {
+		if (idx.chroms[i] != *current) {
+			idx.chrom_offsets.emplace(*current, std::make_pair(run_start, i));
+			current = &idx.chroms[i];
+			run_start = i;
+		}
+	}
+	idx.chrom_offsets.emplace(*current, std::make_pair(run_start, idx.chroms.size()));
+}
+
+//! Parse a single delimited field from [start, end) in buf (no allocation).
+//! Advances *field_start to the start of the next field (after the delimiter),
+//! sets *out_start and *out_len to the span of the current field within buf.
+//! Returns false if no more fields are found. Delim = '\t' for pvar, ' '/'\t' for bim.
+static bool NextField(const char *buf, size_t line_end, size_t *cursor, size_t *out_start, size_t *out_len,
+                      bool whitespace) {
+	size_t i = *cursor;
+	if (whitespace) {
+		while (i < line_end && (buf[i] == ' ' || buf[i] == '\t')) {
+			i++;
+		}
+		if (i >= line_end) {
+			return false;
+		}
+		size_t start = i;
+		while (i < line_end && buf[i] != ' ' && buf[i] != '\t') {
+			i++;
+		}
+		*out_start = start;
+		*out_len = i - start;
+		*cursor = i;
 	} else {
-		end = file_content.size();
-	}
-	// Strip trailing newline characters
-	while (end > static_cast<size_t>(line_offsets[vidx]) &&
-	       (file_content[end - 1] == '\n' || file_content[end - 1] == '\r')) {
-		end--;
-	}
-	return end;
-}
-
-string VariantMetadataIndex::GetField(idx_t vidx, idx_t field_idx) const {
-	auto start = static_cast<size_t>(line_offsets[vidx]);
-	auto line_end = LineEnd(vidx);
-
-	if (is_bim) {
-		// Whitespace-delimited: skip leading whitespace, then find fields
-		idx_t current_field = 0;
-		size_t i = start;
-		while (i < line_end) {
-			// Skip whitespace
-			while (i < line_end && (file_content[i] == ' ' || file_content[i] == '\t')) {
-				i++;
-			}
-			if (i >= line_end) {
-				break;
-			}
-			size_t field_start = i;
-			// Find end of field
-			while (i < line_end && file_content[i] != ' ' && file_content[i] != '\t') {
-				i++;
-			}
-			if (current_field == field_idx) {
-				return string(file_content.data() + field_start, i - field_start);
-			}
-			current_field++;
+		if (i > line_end) {
+			return false;
 		}
-	} else {
-		// Tab-delimited
-		idx_t current_field = 0;
-		size_t field_start = start;
-		for (size_t i = start; i < line_end; i++) {
-			if (file_content[i] == '\t') {
-				if (current_field == field_idx) {
-					return string(file_content.data() + field_start, i - field_start);
-				}
-				current_field++;
-				field_start = i + 1;
-			}
+		size_t start = i;
+		while (i < line_end && buf[i] != '\t') {
+			i++;
 		}
-		// Last field on the line
-		if (current_field == field_idx) {
-			return string(file_content.data() + field_start, line_end - field_start);
-		}
+		*out_start = start;
+		*out_len = i - start;
+		*cursor = i < line_end ? i + 1 : i; // step past the tab
 	}
-
-	throw InternalException("VariantMetadataIndex::GetField: field index %llu out of range for variant %llu",
-	                        static_cast<unsigned long long>(field_idx), static_cast<unsigned long long>(vidx));
-}
-
-string VariantMetadataIndex::GetChrom(idx_t vidx) const {
-	return GetField(vidx, chrom_idx);
-}
-
-int32_t VariantMetadataIndex::GetPos(idx_t vidx) const {
-	auto field = GetField(vidx, pos_idx);
-	char *end;
-	errno = 0;
-	long val = std::strtol(field.c_str(), &end, 10);
-	if (end == field.c_str() || *end != '\0' || errno != 0) {
-		throw InternalException("VariantMetadataIndex::GetPos: invalid POS value '%s' for variant %llu", field.c_str(),
-		                        static_cast<unsigned long long>(vidx));
-	}
-	return static_cast<int32_t>(val);
-}
-
-string VariantMetadataIndex::GetId(idx_t vidx) const {
-	auto field = GetField(vidx, id_idx);
-	if (field == ".") {
-		return "";
-	}
-	return field;
-}
-
-string VariantMetadataIndex::GetRef(idx_t vidx) const {
-	return GetField(vidx, ref_idx);
-}
-
-string VariantMetadataIndex::GetAlt(idx_t vidx) const {
-	auto field = GetField(vidx, alt_idx);
-	if (field == ".") {
-		return "";
-	}
-	return field;
+	return true;
 }
 
 VariantMetadataIndex LoadVariantMetadataIndex(ClientContext &context, const string &path, const string &func_name) {
+	BindPhaseTimer timer("LoadVariantMetadataIndex(text)");
 	auto &fs = FileSystem::GetFileSystem(context);
 	auto handle = fs.OpenFile(path, FileFlags::FILE_FLAGS_READ);
 	auto file_size = handle->GetFileSize();
+	timer.Note("file_size=%llu", static_cast<unsigned long long>(file_size));
 
 	if (file_size == 0) {
 		throw InvalidInputException("%s: .pvar/.bim file '%s' is empty", func_name, path);
 	}
 
+	string file_content;
+	file_content.resize(file_size);
+	handle->Read(const_cast<char *>(file_content.data()), file_size);
+
 	VariantMetadataIndex idx;
-	idx.file_content.resize(file_size);
-	handle->Read(const_cast<char *>(idx.file_content.data()), file_size);
 
-	// Parse header from the in-memory buffer (same logic as LoadVariantMetadata)
+	// --- Header / column layout ---
 	size_t pos = 0;
-
-	// Skip ## comment/meta lines
 	while (pos < file_size) {
-		if (file_size - pos >= 2 && idx.file_content[pos] == '#' && idx.file_content[pos + 1] == '#') {
-			// Skip to next line
-			while (pos < file_size && idx.file_content[pos] != '\n') {
+		if (file_size - pos >= 2 && file_content[pos] == '#' && file_content[pos + 1] == '#') {
+			while (pos < file_size && file_content[pos] != '\n') {
 				pos++;
 			}
 			if (pos < file_size) {
-				pos++; // skip newline
+				pos++;
 			}
 			continue;
 		}
-		if (pos < file_size && idx.file_content[pos] == '\n') {
+		if (pos < file_size && file_content[pos] == '\n') {
 			pos++;
 			continue;
 		}
@@ -229,98 +189,142 @@ VariantMetadataIndex LoadVariantMetadataIndex(ClientContext &context, const stri
 		throw InvalidInputException("%s: .pvar/.bim file '%s' contains no header or data", func_name, path);
 	}
 
-	// Extract the header/first-data line to determine format
 	size_t header_start = pos;
 	size_t header_end = pos;
-	while (header_end < file_size && idx.file_content[header_end] != '\n') {
+	while (header_end < file_size && file_content[header_end] != '\n') {
 		header_end++;
 	}
-	// Strip trailing \r
 	size_t header_content_end = header_end;
-	if (header_content_end > header_start && idx.file_content[header_content_end - 1] == '\r') {
+	if (header_content_end > header_start && file_content[header_content_end - 1] == '\r') {
 		header_content_end--;
 	}
-	string header_line(idx.file_content.data() + header_start, header_content_end - header_start);
+	string header_line(file_content.data() + header_start, header_content_end - header_start);
 
-	vector<string> column_names;
+	idx_t chrom_field = DConstants::INVALID_INDEX;
+	idx_t pos_field = DConstants::INVALID_INDEX;
+	idx_t id_field = DConstants::INVALID_INDEX;
+	idx_t ref_field = DConstants::INVALID_INDEX;
+	idx_t alt_field = DConstants::INVALID_INDEX;
 
 	if (header_line.size() >= 6 && header_line.substr(0, 6) == "#CHROM") {
-		// .pvar format
 		idx.is_bim = false;
-		auto fields = SplitTabLine(header_line.substr(1)); // strip leading '#'
-		column_names = std::move(fields);
-		// Skip past header line
+		auto fields = SplitTabLine(header_line.substr(1));
+		for (idx_t i = 0; i < fields.size(); i++) {
+			if (fields[i] == "CHROM") {
+				chrom_field = i;
+			} else if (fields[i] == "POS") {
+				pos_field = i;
+			} else if (fields[i] == "ID") {
+				id_field = i;
+			} else if (fields[i] == "REF") {
+				ref_field = i;
+			} else if (fields[i] == "ALT") {
+				alt_field = i;
+			}
+		}
 		pos = header_end;
 		if (pos < file_size) {
-			pos++; // skip newline
+			pos++;
 		}
 	} else {
-		// Legacy .bim format: no header to skip, first line is data
 		idx.is_bim = true;
-		// .bim physical columns: CHROM(0) ID(1) CM(2) POS(3) ALT(4) REF(5)
-		// We store physical field indices directly
-		column_names = {"CHROM", "ID", "CM", "POS", "ALT", "REF"};
+		// .bim: CHROM(0) ID(1) CM(2) POS(3) ALT(4) REF(5)
+		chrom_field = 0;
+		id_field = 1;
+		pos_field = 3;
+		alt_field = 4;
+		ref_field = 5;
 	}
 
-	// Find physical column indices
-	idx.chrom_idx = DConstants::INVALID_INDEX;
-	idx.pos_idx = DConstants::INVALID_INDEX;
-	idx.id_idx = DConstants::INVALID_INDEX;
-	idx.ref_idx = DConstants::INVALID_INDEX;
-	idx.alt_idx = DConstants::INVALID_INDEX;
-
-	for (idx_t i = 0; i < column_names.size(); i++) {
-		const auto &name = column_names[i];
-		if (name == "CHROM") {
-			idx.chrom_idx = i;
-		} else if (name == "POS") {
-			idx.pos_idx = i;
-		} else if (name == "ID") {
-			idx.id_idx = i;
-		} else if (name == "REF") {
-			idx.ref_idx = i;
-		} else if (name == "ALT") {
-			idx.alt_idx = i;
-		}
-	}
-
-	if (idx.chrom_idx == DConstants::INVALID_INDEX || idx.pos_idx == DConstants::INVALID_INDEX ||
-	    idx.id_idx == DConstants::INVALID_INDEX || idx.ref_idx == DConstants::INVALID_INDEX ||
-	    idx.alt_idx == DConstants::INVALID_INDEX) {
+	if (chrom_field == DConstants::INVALID_INDEX || pos_field == DConstants::INVALID_INDEX ||
+	    id_field == DConstants::INVALID_INDEX || ref_field == DConstants::INVALID_INDEX ||
+	    alt_field == DConstants::INVALID_INDEX) {
 		throw InvalidInputException("%s: .pvar/.bim file '%s' is missing required columns "
 		                            "(need CHROM, POS, ID, REF, ALT)",
 		                            func_name, path);
 	}
 
-	// Build line offset index: one pass over the buffer
-	// Estimate capacity to avoid reallocation
-	if (file_size > 0) {
-		idx.line_offsets.reserve(file_size / 30); // rough estimate: ~30 bytes per line
-	}
+	// --- Pre-size vectors (rough estimate) ---
+	idx_t capacity = file_size / 30;
+	idx.chroms.reserve(capacity);
+	idx.positions.reserve(capacity);
+	idx.ids.reserve(capacity);
+	idx.refs.reserve(capacity);
+	idx.alts.reserve(capacity);
+
+	// --- Parse each data line directly into columnar vectors ---
+	const idx_t max_field = std::max({chrom_field, pos_field, id_field, ref_field, alt_field});
+	const char *buf = file_content.data();
+	const bool whitespace = idx.is_bim;
 
 	while (pos < file_size) {
-		// Skip empty lines
-		if (idx.file_content[pos] == '\n') {
-			pos++;
+		if (buf[pos] == '\n' || (buf[pos] == '\r' && pos + 1 < file_size && buf[pos + 1] == '\n')) {
+			pos += (buf[pos] == '\r') ? 2 : 1;
 			continue;
 		}
-		if (idx.file_content[pos] == '\r' && pos + 1 < file_size && idx.file_content[pos + 1] == '\n') {
-			pos += 2;
-			continue;
+		size_t line_end = pos;
+		while (line_end < file_size && buf[line_end] != '\n') {
+			line_end++;
+		}
+		size_t content_end = line_end;
+		if (content_end > pos && buf[content_end - 1] == '\r') {
+			content_end--;
 		}
 
-		idx.line_offsets.push_back(static_cast<uint64_t>(pos));
+		size_t cursor = pos;
+		size_t fstart = 0, flen = 0;
+		string chrom, id, ref, alt;
+		int32_t pos_val = 0;
+		for (idx_t f = 0; f <= max_field; f++) {
+			if (!NextField(buf, content_end, &cursor, &fstart, &flen, whitespace)) {
+				break;
+			}
+			if (f == chrom_field) {
+				chrom.assign(buf + fstart, flen);
+			} else if (f == pos_field) {
+				// strtol on a non-nul-terminated span: copy into small local
+				char tmp[32];
+				idx_t n = flen < sizeof(tmp) - 1 ? flen : sizeof(tmp) - 1;
+				std::memcpy(tmp, buf + fstart, n);
+				tmp[n] = '\0';
+				char *end;
+				errno = 0;
+				long v = std::strtol(tmp, &end, 10);
+				if (end == tmp || *end != '\0' || errno != 0) {
+					throw InvalidInputException("%s: invalid POS value '%s' at line offset %llu", func_name, tmp,
+					                            static_cast<unsigned long long>(pos));
+				}
+				pos_val = static_cast<int32_t>(v);
+			} else if (f == id_field) {
+				if (flen == 1 && buf[fstart] == '.') {
+					// empty
+				} else {
+					id.assign(buf + fstart, flen);
+				}
+			} else if (f == ref_field) {
+				ref.assign(buf + fstart, flen);
+			} else if (f == alt_field) {
+				if (flen == 1 && buf[fstart] == '.') {
+					// empty
+				} else {
+					alt.assign(buf + fstart, flen);
+				}
+			}
+		}
 
-		// Scan to next newline
-		while (pos < file_size && idx.file_content[pos] != '\n') {
-			pos++;
-		}
-		if (pos < file_size) {
-			pos++; // skip newline
-		}
+		idx.chroms.emplace_back(std::move(chrom));
+		idx.positions.push_back(pos_val);
+		idx.ids.emplace_back(std::move(id));
+		idx.refs.emplace_back(std::move(ref));
+		idx.alts.emplace_back(std::move(alt));
+
+		pos = line_end < file_size ? line_end + 1 : line_end;
 	}
 
-	idx.variant_ct = idx.line_offsets.size();
+	idx.variant_ct = idx.chroms.size();
+	idx.has_ids = true;
+	idx.has_alleles = true;
+	BuildChromOffsets(idx);
 	return idx;
 }
 
@@ -457,23 +461,21 @@ string FindCompanionFileWithParquet(ClientContext &context, FileSystem &fs, cons
 // Parquet companion loading
 // ---------------------------------------------------------------------------
 
-VariantMetadataIndex LoadVariantMetadataFromParquet(ClientContext &context, const string &path,
-                                                    const string &func_name) {
-	// Use a separate connection to read the parquet file (avoids bind reentrancy)
-	auto &db = DatabaseInstance::GetDatabase(context);
-	Connection conn(db);
-	auto result = conn.TableFunction("parquet_scan", {Value(path)})->Execute();
-	if (result->HasError()) {
-		throw IOException("%s: failed to read parquet companion '%s': %s", func_name, path, result->GetError());
-	}
-
-	// Map columns by name (case-insensitive)
-	auto &col_names = result->names;
+//! Columnar ingestion helper. Scans a QueryResult and populates idx with
+//! columnar-typed vectors. Maps columns by name (case-insensitive).
+//! row_number_col: if != INVALID_INDEX, interpreted as a BIGINT file_row_number
+//! column; the resulting index is sparse (idx.vidx_map populated). Otherwise
+//! the index is dense (indexed by emit order).
+static void IngestVariantResult(QueryResult &result, const string &source_label, const string &func_name,
+                                VariantMetadataIndex &idx) {
+	auto &col_names = result.names;
+	auto &col_types = result.types;
 	idx_t chrom_col = DConstants::INVALID_INDEX;
 	idx_t pos_col = DConstants::INVALID_INDEX;
 	idx_t id_col = DConstants::INVALID_INDEX;
 	idx_t ref_col = DConstants::INVALID_INDEX;
 	idx_t alt_col = DConstants::INVALID_INDEX;
+	idx_t rn_col = DConstants::INVALID_INDEX;
 
 	for (idx_t i = 0; i < col_names.size(); i++) {
 		auto lower = StringUtil::Lower(col_names[i]);
@@ -487,87 +489,288 @@ VariantMetadataIndex LoadVariantMetadataFromParquet(ClientContext &context, cons
 			ref_col = i;
 		} else if (lower == "alt") {
 			alt_col = i;
+		} else if (lower == "file_row_number") {
+			rn_col = i;
 		}
 	}
 
 	if (chrom_col == DConstants::INVALID_INDEX || pos_col == DConstants::INVALID_INDEX) {
-		throw InvalidInputException("%s: parquet companion '%s' missing required columns "
-		                            "(need CHROM and POS, found: %s)",
-		                            func_name, path, StringUtil::Join(col_names, ", "));
+		throw InvalidInputException("%s: %s missing required columns (need CHROM and POS, found: %s)", func_name,
+		                            source_label, StringUtil::Join(col_names, ", "));
 	}
 
-	// Synthesize a .pvar-format text buffer from the parquet data
-	string buf;
-	buf += "#CHROM\tPOS\tID\tREF\tALT\n";
+	auto pos_type_id = col_types[pos_col].id();
+	if (pos_type_id != LogicalTypeId::INTEGER && pos_type_id != LogicalTypeId::BIGINT &&
+	    pos_type_id != LogicalTypeId::UINTEGER && pos_type_id != LogicalTypeId::UBIGINT) {
+		throw InvalidInputException("%s: %s POS column has unsupported type %s (expected INTEGER/BIGINT)", func_name,
+		                            source_label, col_types[pos_col].ToString());
+	}
+	auto chrom_type_id = col_types[chrom_col].id();
+	bool chrom_is_integer = (chrom_type_id == LogicalTypeId::INTEGER || chrom_type_id == LogicalTypeId::BIGINT ||
+	                         chrom_type_id == LogicalTypeId::UINTEGER || chrom_type_id == LogicalTypeId::UBIGINT);
 
 	unique_ptr<DataChunk> chunk;
-	while ((chunk = result->Fetch()) != nullptr && chunk->size() > 0) {
-		for (idx_t row = 0; row < chunk->size(); row++) {
-			buf += chunk->GetValue(chrom_col, row).ToString();
-			buf += '\t';
-			buf += chunk->GetValue(pos_col, row).ToString();
-			buf += '\t';
-			buf += (id_col != DConstants::INVALID_INDEX) ? chunk->GetValue(id_col, row).ToString() : ".";
-			buf += '\t';
-			buf += (ref_col != DConstants::INVALID_INDEX) ? chunk->GetValue(ref_col, row).ToString() : ".";
-			buf += '\t';
-			buf += (alt_col != DConstants::INVALID_INDEX) ? chunk->GetValue(alt_col, row).ToString() : ".";
-			buf += '\n';
+	while ((chunk = result.Fetch()) != nullptr && chunk->size() > 0) {
+		idx_t n = chunk->size();
+
+		// CHROM — may be VARCHAR or numeric
+		{
+			auto &vec = chunk->data[chrom_col];
+			UnifiedVectorFormat uvf;
+			vec.ToUnifiedFormat(n, uvf);
+			if (chrom_is_integer) {
+				// Render numeric chrom as string for consistency with text .pvar
+				for (idx_t i = 0; i < n; i++) {
+					auto si = uvf.sel->get_index(i);
+					if (!uvf.validity.RowIsValid(si)) {
+						idx.chroms.emplace_back();
+					} else {
+						int64_t v;
+						if (chrom_type_id == LogicalTypeId::INTEGER) {
+							v = reinterpret_cast<const int32_t *>(uvf.data)[si];
+						} else if (chrom_type_id == LogicalTypeId::BIGINT) {
+							v = reinterpret_cast<const int64_t *>(uvf.data)[si];
+						} else if (chrom_type_id == LogicalTypeId::UINTEGER) {
+							v = reinterpret_cast<const uint32_t *>(uvf.data)[si];
+						} else {
+							v = static_cast<int64_t>(reinterpret_cast<const uint64_t *>(uvf.data)[si]);
+						}
+						idx.chroms.emplace_back(std::to_string(v));
+					}
+				}
+			} else {
+				auto data = reinterpret_cast<const string_t *>(uvf.data);
+				for (idx_t i = 0; i < n; i++) {
+					auto si = uvf.sel->get_index(i);
+					if (!uvf.validity.RowIsValid(si)) {
+						idx.chroms.emplace_back();
+					} else {
+						idx.chroms.emplace_back(data[si].GetData(), data[si].GetSize());
+					}
+				}
+			}
+		}
+
+		// POS — widen to int32 (pgen uses int32)
+		{
+			auto &vec = chunk->data[pos_col];
+			UnifiedVectorFormat uvf;
+			vec.ToUnifiedFormat(n, uvf);
+			for (idx_t i = 0; i < n; i++) {
+				auto si = uvf.sel->get_index(i);
+				int32_t v = 0;
+				if (uvf.validity.RowIsValid(si)) {
+					if (pos_type_id == LogicalTypeId::INTEGER) {
+						v = reinterpret_cast<const int32_t *>(uvf.data)[si];
+					} else if (pos_type_id == LogicalTypeId::BIGINT) {
+						v = static_cast<int32_t>(reinterpret_cast<const int64_t *>(uvf.data)[si]);
+					} else if (pos_type_id == LogicalTypeId::UINTEGER) {
+						v = static_cast<int32_t>(reinterpret_cast<const uint32_t *>(uvf.data)[si]);
+					} else {
+						v = static_cast<int32_t>(reinterpret_cast<const uint64_t *>(uvf.data)[si]);
+					}
+				}
+				idx.positions.push_back(v);
+			}
+		}
+
+		// ID — VARCHAR, "." → ""
+		{
+			if (id_col == DConstants::INVALID_INDEX) {
+				for (idx_t i = 0; i < n; i++) {
+					idx.ids.emplace_back();
+				}
+			} else {
+				auto &vec = chunk->data[id_col];
+				UnifiedVectorFormat uvf;
+				vec.ToUnifiedFormat(n, uvf);
+				auto data = reinterpret_cast<const string_t *>(uvf.data);
+				for (idx_t i = 0; i < n; i++) {
+					auto si = uvf.sel->get_index(i);
+					if (!uvf.validity.RowIsValid(si)) {
+						idx.ids.emplace_back();
+					} else {
+						auto sz = data[si].GetSize();
+						auto d = data[si].GetData();
+						if (sz == 1 && d[0] == '.') {
+							idx.ids.emplace_back();
+						} else {
+							idx.ids.emplace_back(d, sz);
+						}
+					}
+				}
+			}
+		}
+
+		// REF — VARCHAR (plain copy)
+		{
+			if (ref_col == DConstants::INVALID_INDEX) {
+				for (idx_t i = 0; i < n; i++) {
+					idx.refs.emplace_back();
+				}
+			} else {
+				auto &vec = chunk->data[ref_col];
+				UnifiedVectorFormat uvf;
+				vec.ToUnifiedFormat(n, uvf);
+				auto data = reinterpret_cast<const string_t *>(uvf.data);
+				for (idx_t i = 0; i < n; i++) {
+					auto si = uvf.sel->get_index(i);
+					if (!uvf.validity.RowIsValid(si)) {
+						idx.refs.emplace_back();
+					} else {
+						idx.refs.emplace_back(data[si].GetData(), data[si].GetSize());
+					}
+				}
+			}
+		}
+
+		// ALT — VARCHAR, "." → ""
+		{
+			if (alt_col == DConstants::INVALID_INDEX) {
+				for (idx_t i = 0; i < n; i++) {
+					idx.alts.emplace_back();
+				}
+			} else {
+				auto &vec = chunk->data[alt_col];
+				UnifiedVectorFormat uvf;
+				vec.ToUnifiedFormat(n, uvf);
+				auto data = reinterpret_cast<const string_t *>(uvf.data);
+				for (idx_t i = 0; i < n; i++) {
+					auto si = uvf.sel->get_index(i);
+					if (!uvf.validity.RowIsValid(si)) {
+						idx.alts.emplace_back();
+					} else {
+						auto sz = data[si].GetSize();
+						auto d = data[si].GetData();
+						if (sz == 1 && d[0] == '.') {
+							idx.alts.emplace_back();
+						} else {
+							idx.alts.emplace_back(d, sz);
+						}
+					}
+				}
+			}
+		}
+
+		// file_row_number → sparse vidx_map
+		if (rn_col != DConstants::INVALID_INDEX) {
+			auto &vec = chunk->data[rn_col];
+			UnifiedVectorFormat uvf;
+			vec.ToUnifiedFormat(n, uvf);
+			auto data = reinterpret_cast<const int64_t *>(uvf.data);
+			idx_t local_base = idx.chroms.size() - n;
+			for (idx_t i = 0; i < n; i++) {
+				auto si = uvf.sel->get_index(i);
+				if (!uvf.validity.RowIsValid(si)) {
+					throw IOException("%s: NULL file_row_number encountered (internal error)", func_name);
+				}
+				idx.vidx_map.emplace(static_cast<uint32_t>(data[si]), static_cast<uint32_t>(local_base + i));
+			}
 		}
 	}
-
-	// Parse the synthetic buffer using the existing text parser
-	VariantMetadataIndex idx;
-	idx.file_content = std::move(buf);
-	idx.is_bim = false;
-	idx.chrom_idx = 0;
-	idx.pos_idx = 1;
-	idx.id_idx = 2;
-	idx.ref_idx = 3;
-	idx.alt_idx = 4;
-
-	// Build line offsets — skip the header line (first line ending with \n)
-	size_t pos = 0;
-	// Skip header line
-	while (pos < idx.file_content.size() && idx.file_content[pos] != '\n') {
-		pos++;
-	}
-	if (pos < idx.file_content.size()) {
-		pos++; // skip newline
-	}
-
-	// Index data lines
-	while (pos < idx.file_content.size()) {
-		if (idx.file_content[pos] == '\n') {
-			pos++;
-			continue;
-		}
-		idx.line_offsets.push_back(static_cast<uint64_t>(pos));
-		while (pos < idx.file_content.size() && idx.file_content[pos] != '\n') {
-			pos++;
-		}
-		if (pos < idx.file_content.size()) {
-			pos++;
-		}
-	}
-
-	idx.variant_ct = idx.line_offsets.size();
-	return idx;
 }
 
-SampleInfo LoadSampleInfoFromParquet(ClientContext &context, const string &path) {
+VariantMetadataIndex LoadVariantMetadataFromParquet(ClientContext &context, const string &path,
+                                                    const string &func_name) {
+	BindPhaseTimer timer("LoadVariantMetadataFromParquet");
 	auto &db = DatabaseInstance::GetDatabase(context);
 	Connection conn(db);
 	auto result = conn.TableFunction("parquet_scan", {Value(path)})->Execute();
+	timer.Note("parquet_scan opened");
 	if (result->HasError()) {
-		throw IOException("Failed to read parquet companion '%s': %s", path, result->GetError());
+		throw IOException("%s: failed to read parquet companion '%s': %s", func_name, path, result->GetError());
 	}
 
-	// Map columns by name (case-insensitive)
-	auto &col_names = result->names;
+	VariantMetadataIndex idx;
+	idx.is_bim = false;
+	string label = "parquet companion '" + path + "'";
+	IngestVariantResult(*result, label, func_name, idx);
+	idx.variant_ct = idx.chroms.size();
+	idx.has_ids = true;
+	idx.has_alleles = true;
+	timer.Note("ingested %llu variants", (unsigned long long)idx.variant_ct);
+	BuildChromOffsets(idx);
+	timer.Note("built chrom_offsets (%llu chroms)", (unsigned long long)idx.chrom_offsets.size());
+	return idx;
+}
+
+//! Region-pushdown loader: queries the parquet file with a WHERE clause so
+//! only matching rows are materialized. Returns a sparse index whose
+//! vidx_map keys are the file row numbers (pgenlib-compatible vidx).
+//! total_row_ct lets caller set variant_ct correctly for count validation.
+VariantMetadataIndex LoadVariantMetadataFromParquetRegion(ClientContext &context, const string &path,
+                                                          const string &chrom, int64_t pos_start, int64_t pos_end,
+                                                          idx_t total_row_ct, const string &func_name) {
+	BindPhaseTimer timer("LoadVariantMetadataFromParquetRegion");
+	auto &db = DatabaseInstance::GetDatabase(context);
+	Connection conn(db);
+	auto escaped_path = StringUtil::Replace(path, "'", "''");
+	auto escaped_chrom = StringUtil::Replace(chrom, "'", "''");
+
+	// file_row_number gives pgenlib-compatible global vidx; stats pruning + column
+	// projection keep this O(region_size), not O(total).
+	string sql = "SELECT \"#CHROM\" AS \"#CHROM\", POS, ID, REF, ALT, file_row_number "
+	             "FROM read_parquet('" +
+	             escaped_path +
+	             "', file_row_number=true) "
+	             "WHERE (CAST(\"#CHROM\" AS VARCHAR) = '" +
+	             escaped_chrom + "') AND POS BETWEEN " + std::to_string(pos_start) + " AND " + std::to_string(pos_end) +
+	             " ORDER BY file_row_number";
+	auto result = conn.Query(sql);
+	if (result->HasError()) {
+		// Retry without `#` prefix column alias if the file uses "CHROM" (alias still selects by position)
+		auto alt_sql = "SELECT CHROM AS \"#CHROM\", POS, ID, REF, ALT, file_row_number "
+		               "FROM read_parquet('" +
+		               escaped_path +
+		               "', file_row_number=true) "
+		               "WHERE (CAST(CHROM AS VARCHAR) = '" +
+		               escaped_chrom + "') AND POS BETWEEN " + std::to_string(pos_start) + " AND " +
+		               std::to_string(pos_end) + " ORDER BY file_row_number";
+		result = conn.Query(alt_sql);
+		if (result->HasError()) {
+			throw IOException("%s: region-pushdown query failed on '%s': %s", func_name, path, result->GetError());
+		}
+	}
+	timer.Note("pushdown query returned");
+
+	VariantMetadataIndex idx;
+	idx.is_bim = false;
+	string label = "parquet companion '" + path + "' (region pushdown)";
+	IngestVariantResult(*result, label, func_name, idx);
+	idx.variant_ct = total_row_ct; // total from parquet metadata (for count-mismatch validation)
+	idx.has_ids = true;
+	idx.has_alleles = true;
+	// Single chrom in pushdown, single contiguous range of local indices
+	if (!idx.chroms.empty()) {
+		idx.chrom_offsets.emplace(idx.chroms.front(), std::make_pair(idx_t {0}, idx.chroms.size()));
+	}
+	timer.Note("ingested %llu region variants (total_ct=%llu)", (unsigned long long)idx.chroms.size(),
+	           (unsigned long long)total_row_ct);
+	return idx;
+}
+
+//! Get total row count from a parquet file via its footer metadata (no row scan).
+idx_t GetParquetRowCount(ClientContext &context, const string &path) {
+	auto &db = DatabaseInstance::GetDatabase(context);
+	Connection conn(db);
+	auto escaped = StringUtil::Replace(path, "'", "''");
+	auto result = conn.Query("SELECT COUNT(*) FROM read_parquet('" + escaped + "')");
+	if (result->HasError()) {
+		throw IOException("Failed to get row count for '%s': %s", path, result->GetError());
+	}
+	auto chunk = result->Fetch();
+	if (!chunk || chunk->size() == 0) {
+		return 0;
+	}
+	return static_cast<idx_t>(chunk->GetValue(0, 0).GetValue<int64_t>());
+}
+
+//! Columnar ingest helper for psam query results.
+static void IngestSampleResult(QueryResult &result, const string &source_label, SampleInfo &info, bool load_iids,
+                               bool load_fids) {
+	auto &col_names = result.names;
 	idx_t iid_col = DConstants::INVALID_INDEX;
 	idx_t fid_col = DConstants::INVALID_INDEX;
-
 	for (idx_t i = 0; i < col_names.size(); i++) {
 		auto lower = StringUtil::Lower(col_names[i]);
 		if (lower == "iid") {
@@ -576,33 +779,67 @@ SampleInfo LoadSampleInfoFromParquet(ClientContext &context, const string &path)
 			fid_col = i;
 		}
 	}
-
 	if (iid_col == DConstants::INVALID_INDEX) {
-		throw InvalidInputException("Parquet companion '%s' missing required IID column (found: %s)", path,
+		throw InvalidInputException("%s missing required IID column (found: %s)", source_label,
 		                            StringUtil::Join(col_names, ", "));
+	}
+	bool has_fid_col = (fid_col != DConstants::INVALID_INDEX);
+
+	idx_t total_rows = 0;
+	unique_ptr<DataChunk> chunk;
+	while ((chunk = result.Fetch()) != nullptr && chunk->size() > 0) {
+		idx_t n = chunk->size();
+		total_rows += n;
+
+		if (load_iids) {
+			auto &vec = chunk->data[iid_col];
+			UnifiedVectorFormat uvf;
+			vec.ToUnifiedFormat(n, uvf);
+			auto data = reinterpret_cast<const string_t *>(uvf.data);
+			for (idx_t i = 0; i < n; i++) {
+				auto si = uvf.sel->get_index(i);
+				if (!uvf.validity.RowIsValid(si)) {
+					info.iids.emplace_back();
+				} else {
+					info.iids.emplace_back(data[si].GetData(), data[si].GetSize());
+				}
+			}
+		}
+		if (load_fids && has_fid_col) {
+			auto &vec = chunk->data[fid_col];
+			UnifiedVectorFormat uvf;
+			vec.ToUnifiedFormat(n, uvf);
+			auto data = reinterpret_cast<const string_t *>(uvf.data);
+			for (idx_t i = 0; i < n; i++) {
+				auto si = uvf.sel->get_index(i);
+				if (!uvf.validity.RowIsValid(si)) {
+					info.fids.emplace_back();
+				} else {
+					info.fids.emplace_back(data[si].GetData(), data[si].GetSize());
+				}
+			}
+		}
+	}
+	if (!load_iids) {
+		info.sample_ct = total_rows;
+	}
+}
+
+SampleInfo LoadSampleInfoFromParquet(ClientContext &context, const string &path) {
+	BindPhaseTimer timer("LoadSampleInfoFromParquet");
+	auto &db = DatabaseInstance::GetDatabase(context);
+	Connection conn(db);
+	auto result = conn.TableFunction("parquet_scan", {Value(path)})->Execute();
+	timer.Note("parquet_scan opened");
+	if (result->HasError()) {
+		throw IOException("Failed to read parquet companion '%s': %s", path, result->GetError());
 	}
 
 	SampleInfo info;
-	bool has_fid = (fid_col != DConstants::INVALID_INDEX);
-
-	unique_ptr<DataChunk> chunk;
-	while ((chunk = result->Fetch()) != nullptr && chunk->size() > 0) {
-		for (idx_t row = 0; row < chunk->size(); row++) {
-			auto iid = chunk->GetValue(iid_col, row).ToString();
-
-			if (info.iid_to_idx.count(iid)) {
-				throw IOException("Parquet companion '%s' has duplicate IID '%s'", path, iid);
-			}
-
-			info.iids.push_back(iid);
-			if (has_fid) {
-				info.fids.push_back(chunk->GetValue(fid_col, row).ToString());
-			}
-			info.iid_to_idx[iid] = info.iids.size() - 1;
-		}
-	}
-
+	string label = "parquet companion '" + path + "'";
+	IngestSampleResult(*result, label, info, /*load_iids=*/true, /*load_fids=*/true);
 	info.sample_ct = info.iids.size();
+	timer.Note("loaded %llu samples (iid_to_idx deferred)", (unsigned long long)info.sample_ct);
 	return info;
 }
 
@@ -628,137 +865,26 @@ static unique_ptr<MaterializedQueryResult> QuerySource(ClientContext &context, c
 
 VariantMetadataIndex LoadVariantMetadataFromSource(ClientContext &context, const string &source,
                                                    const string &func_name) {
+	BindPhaseTimer timer("LoadVariantMetadataFromSource");
 	auto result = QuerySource(context, source, func_name);
 
-	// Map columns by name (case-insensitive) — same logic as parquet loader
-	auto &col_names = result->names;
-	idx_t chrom_col = DConstants::INVALID_INDEX;
-	idx_t pos_col = DConstants::INVALID_INDEX;
-	idx_t id_col = DConstants::INVALID_INDEX;
-	idx_t ref_col = DConstants::INVALID_INDEX;
-	idx_t alt_col = DConstants::INVALID_INDEX;
-
-	for (idx_t i = 0; i < col_names.size(); i++) {
-		auto lower = StringUtil::Lower(col_names[i]);
-		if (lower == "chrom" || lower == "#chrom") {
-			chrom_col = i;
-		} else if (lower == "pos") {
-			pos_col = i;
-		} else if (lower == "id") {
-			id_col = i;
-		} else if (lower == "ref") {
-			ref_col = i;
-		} else if (lower == "alt") {
-			alt_col = i;
-		}
-	}
-
-	if (chrom_col == DConstants::INVALID_INDEX || pos_col == DConstants::INVALID_INDEX) {
-		throw InvalidInputException("%s: source '%s' missing required columns "
-		                            "(need CHROM and POS, found: %s)",
-		                            func_name, source, StringUtil::Join(col_names, ", "));
-	}
-
-	// Synthesize a .pvar-format text buffer from the query result
-	string buf;
-	buf += "#CHROM\tPOS\tID\tREF\tALT\n";
-
-	unique_ptr<DataChunk> chunk;
-	while ((chunk = result->Fetch()) != nullptr && chunk->size() > 0) {
-		for (idx_t row = 0; row < chunk->size(); row++) {
-			buf += chunk->GetValue(chrom_col, row).ToString();
-			buf += '\t';
-			buf += chunk->GetValue(pos_col, row).ToString();
-			buf += '\t';
-			buf += (id_col != DConstants::INVALID_INDEX) ? chunk->GetValue(id_col, row).ToString() : ".";
-			buf += '\t';
-			buf += (ref_col != DConstants::INVALID_INDEX) ? chunk->GetValue(ref_col, row).ToString() : ".";
-			buf += '\t';
-			buf += (alt_col != DConstants::INVALID_INDEX) ? chunk->GetValue(alt_col, row).ToString() : ".";
-			buf += '\n';
-		}
-	}
-
-	// Parse the synthetic buffer using the existing text parser structure
 	VariantMetadataIndex idx;
-	idx.file_content = std::move(buf);
 	idx.is_bim = false;
-	idx.chrom_idx = 0;
-	idx.pos_idx = 1;
-	idx.id_idx = 2;
-	idx.ref_idx = 3;
-	idx.alt_idx = 4;
-
-	// Build line offsets — skip the header line (first line ending with \n)
-	size_t pos = 0;
-	while (pos < idx.file_content.size() && idx.file_content[pos] != '\n') {
-		pos++;
-	}
-	if (pos < idx.file_content.size()) {
-		pos++; // skip newline
-	}
-
-	// Index data lines
-	while (pos < idx.file_content.size()) {
-		if (idx.file_content[pos] == '\n') {
-			pos++;
-			continue;
-		}
-		idx.line_offsets.push_back(static_cast<uint64_t>(pos));
-		while (pos < idx.file_content.size() && idx.file_content[pos] != '\n') {
-			pos++;
-		}
-		if (pos < idx.file_content.size()) {
-			pos++;
-		}
-	}
-
-	idx.variant_ct = idx.line_offsets.size();
+	string label = "source '" + source + "'";
+	IngestVariantResult(*result, label, func_name, idx);
+	idx.variant_ct = idx.chroms.size();
+	idx.has_ids = true;
+	idx.has_alleles = true;
+	BuildChromOffsets(idx);
 	return idx;
 }
 
 SampleInfo LoadSampleInfoFromSource(ClientContext &context, const string &source) {
+	BindPhaseTimer timer("LoadSampleInfoFromSource");
 	auto result = QuerySource(context, source, "LoadSampleInfoFromSource");
-
-	// Map columns by name (case-insensitive) — same logic as parquet loader
-	auto &col_names = result->names;
-	idx_t iid_col = DConstants::INVALID_INDEX;
-	idx_t fid_col = DConstants::INVALID_INDEX;
-
-	for (idx_t i = 0; i < col_names.size(); i++) {
-		auto lower = StringUtil::Lower(col_names[i]);
-		if (lower == "iid") {
-			iid_col = i;
-		} else if (lower == "fid") {
-			fid_col = i;
-		}
-	}
-
-	if (iid_col == DConstants::INVALID_INDEX) {
-		throw InvalidInputException("Source '%s' missing required IID column (found: %s)", source,
-		                            StringUtil::Join(col_names, ", "));
-	}
-
 	SampleInfo info;
-	bool has_fid = (fid_col != DConstants::INVALID_INDEX);
-
-	unique_ptr<DataChunk> chunk;
-	while ((chunk = result->Fetch()) != nullptr && chunk->size() > 0) {
-		for (idx_t row = 0; row < chunk->size(); row++) {
-			auto iid = chunk->GetValue(iid_col, row).ToString();
-
-			if (info.iid_to_idx.count(iid)) {
-				throw IOException("Source '%s' has duplicate IID '%s'", source, iid);
-			}
-
-			info.iids.push_back(iid);
-			if (has_fid) {
-				info.fids.push_back(chunk->GetValue(fid_col, row).ToString());
-			}
-			info.iid_to_idx[iid] = info.iids.size() - 1;
-		}
-	}
-
+	string label = "source '" + source + "'";
+	IngestSampleResult(*result, label, info, /*load_iids=*/true, /*load_fids=*/true);
 	info.sample_ct = info.iids.size();
 	return info;
 }
@@ -768,25 +894,41 @@ SampleInfo LoadSampleInfoFromSource(ClientContext &context, const string &source
 // ---------------------------------------------------------------------------
 
 VariantMetadataIndex LoadVariantMetadata(ClientContext &context, const string &path, const string &func_name) {
+	BindPhaseTimer timer("LoadVariantMetadata(dispatch:" + path + ")");
 	if (IsParquetFile(path)) {
 		return LoadVariantMetadataFromParquet(context, path, func_name);
 	}
 	if (IsNativePlinkFormat(path)) {
 		return LoadVariantMetadataIndex(context, path, func_name);
 	}
-	// Arbitrary source (CSV, table, view, etc.)
 	return LoadVariantMetadataFromSource(context, path, func_name);
 }
 
 SampleInfo LoadSampleMetadata(ClientContext &context, const string &path) {
+	BindPhaseTimer timer("LoadSampleMetadata(dispatch:" + path + ")");
 	if (IsParquetFile(path)) {
 		return LoadSampleInfoFromParquet(context, path);
 	}
 	if (IsNativePlinkFormat(path)) {
 		return LoadSampleInfo(context, path);
 	}
-	// Arbitrary source (CSV, table, view, etc.)
 	return LoadSampleInfoFromSource(context, path);
+}
+
+SampleInfo LoadSampleCount(ClientContext &context, const string &path) {
+	BindPhaseTimer timer("LoadSampleCount(" + path + ")");
+	SampleInfo info;
+	if (IsParquetFile(path)) {
+		info.sample_ct = GetParquetRowCount(context, path);
+		timer.Note("parquet metadata count = %llu", (unsigned long long)info.sample_ct);
+		return info;
+	}
+	// Text/source: no efficient metadata-only count, fall through to a full load
+	// then drop the IIDs to keep RSS predictable.
+	auto full = IsNativePlinkFormat(path) ? LoadSampleInfo(context, path) : LoadSampleInfoFromSource(context, path);
+	info.sample_ct = full.sample_ct;
+	timer.Note("text fallback count = %llu (iids discarded)", (unsigned long long)info.sample_ct);
+	return info;
 }
 
 // ---------------------------------------------------------------------------
@@ -819,6 +961,9 @@ vector<uint32_t> ResolveSampleIndices(const Value &samples_val, uint32_t raw_sam
 			                            "is available (no sample IDs to match against)",
 			                            func_name);
 		}
+		// Lazily build iid_to_idx — we only pay the ~500ms map-build cost at 7M
+		// samples when VARCHAR sample filter is actually used.
+		const_cast<SampleInfo *>(sample_info)->EnsureIidMap(func_name);
 		for (auto &child : children) {
 			auto iid = child.GetValue<string>();
 			auto it = sample_info->iid_to_idx.find(iid);
@@ -911,31 +1056,52 @@ VariantRange ParseRegion(const string &region_str, const VariantMetadataIndex &v
 		throw InvalidInputException("%s: invalid region end position in '%s'", func_name, region_str);
 	}
 
-	// Scan variant metadata using on-demand field parsing
 	VariantRange range;
 	range.has_filter = true;
 
-	bool found_start = false;
-	for (uint32_t i = 0; i < static_cast<uint32_t>(variants.variant_ct); i++) {
-		auto v_chrom = variants.GetField(i, variants.chrom_idx);
-		if (v_chrom != chrom) {
-			if (found_start) {
-				break; // Past the matching chromosome block
+	// Fast path: chrom_offsets + binary search on POS (O(log N) per bound).
+	auto it = variants.chrom_offsets.find(chrom);
+	if (it == variants.chrom_offsets.end()) {
+		return range; // empty
+	}
+	idx_t lo_local = it->second.first;
+	idx_t hi_local = it->second.second;
+
+	auto lb_local = [&](int32_t target) {
+		idx_t lo = lo_local, hi = hi_local;
+		while (lo < hi) {
+			idx_t mid = lo + (hi - lo) / 2;
+			if (variants.positions[mid] < target) {
+				lo = mid + 1;
+			} else {
+				hi = mid;
 			}
-			continue;
 		}
-		auto v_pos = variants.GetPos(i);
-		if (v_pos >= static_cast<int32_t>(start_pos) && v_pos <= static_cast<int32_t>(end_pos)) {
-			if (!found_start) {
-				range.start_idx = i;
-				found_start = true;
+		return lo;
+	};
+	idx_t start_local = lb_local(static_cast<int32_t>(start_pos));
+	// Upper bound for end: first index with pos > end_pos.
+	idx_t end_local = lo_local;
+	{
+		idx_t lo = lo_local, hi = hi_local;
+		while (lo < hi) {
+			idx_t mid = lo + (hi - lo) / 2;
+			if (variants.positions[mid] <= static_cast<int32_t>(end_pos)) {
+				lo = mid + 1;
+			} else {
+				hi = mid;
 			}
-			range.end_idx = i + 1;
-		} else if (found_start && v_pos > static_cast<int32_t>(end_pos)) {
-			break; // Past the matching position range within the chromosome
 		}
+		end_local = lo;
 	}
 
+	// VariantRange is expressed in file-row vidx. In dense mode local == vidx.
+	// Sparse indexes shouldn't hit this path (they've been pre-filtered).
+	if (!variants.vidx_map.empty() && start_local < end_local) {
+		throw InternalException("ParseRegion: sparse variant index should not re-filter by region");
+	}
+	range.start_idx = static_cast<uint32_t>(start_local);
+	range.end_idx = static_cast<uint32_t>(end_local);
 	return range;
 }
 
@@ -1156,9 +1322,70 @@ static unordered_map<string, uint32_t> BuildVariantIdIndex(const VariantMetadata
 	return id_to_idx;
 }
 
+//! Lookup by (chrom, pos[, ref, alt]) using chrom_offsets + binary search on POS.
+//! Returns the file-row vidx. Falls back to linear scan if chrom_offsets unavailable.
+static uint32_t ResolveByCpra(const VariantMetadataIndex &variants, const string &chrom, int32_t pos,
+                              const string *ref_match, const string *alt_match, const string &desc,
+                              const string &func_name) {
+	idx_t lo_local = 0;
+	idx_t hi_local = variants.chroms.size();
+	if (!variants.chrom_offsets.empty()) {
+		auto it = variants.chrom_offsets.find(chrom);
+		if (it == variants.chrom_offsets.end()) {
+			throw InvalidInputException("%s: variant '%s' not found", func_name, desc);
+		}
+		lo_local = it->second.first;
+		hi_local = it->second.second;
+	}
+
+	// Binary search on positions[lo_local..hi_local) — POS is sorted ascending within chrom.
+	idx_t lo = lo_local, hi = hi_local;
+	while (lo < hi) {
+		idx_t mid = lo + (hi - lo) / 2;
+		if (variants.positions[mid] < pos) {
+			lo = mid + 1;
+		} else {
+			hi = mid;
+		}
+	}
+	// Equal-range scan: there may be multiple variants at the same (chrom, pos) differing in alleles.
+	for (idx_t i = lo; i < hi_local && variants.positions[i] == pos; i++) {
+		if (variants.chrom_offsets.empty() && variants.chroms[i] != chrom) {
+			continue; // fallback path: chrom check needed
+		}
+		if (ref_match && alt_match) {
+			if (variants.refs[i] == *ref_match && variants.alts[i] == *alt_match) {
+				// Map local idx back to file-row vidx
+				if (!variants.vidx_map.empty()) {
+					for (auto &kv : variants.vidx_map) {
+						if (kv.second == i) {
+							return kv.first;
+						}
+					}
+					throw InternalException("ResolveByCpra: local idx %llu missing from vidx_map",
+					                        static_cast<unsigned long long>(i));
+				}
+				return static_cast<uint32_t>(i);
+			}
+		} else {
+			if (!variants.vidx_map.empty()) {
+				for (auto &kv : variants.vidx_map) {
+					if (kv.second == i) {
+						return kv.first;
+					}
+				}
+				throw InternalException("ResolveByCpra: local idx %llu missing from vidx_map",
+				                        static_cast<unsigned long long>(i));
+			}
+			return static_cast<uint32_t>(i);
+		}
+	}
+
+	throw InvalidInputException("%s: variant '%s' not found", func_name, desc);
+}
+
 //! Resolve a single CPRA string (chrom:pos or chrom:pos:ref:alt) to a variant index.
 static uint32_t ResolveCpraString(const string &cpra, const VariantMetadataIndex &variants, const string &func_name) {
-	// Split on ':'
 	vector<string> parts;
 	size_t start = 0;
 	for (size_t i = 0; i <= cpra.size(); i++) {
@@ -1173,7 +1400,6 @@ static uint32_t ResolveCpraString(const string &cpra, const VariantMetadataIndex
 		                            cpra);
 	}
 
-	auto &chrom = parts[0];
 	char *end_ptr;
 	errno = 0;
 	long pos = std::strtol(parts[1].c_str(), &end_ptr, 10);
@@ -1182,25 +1408,8 @@ static uint32_t ResolveCpraString(const string &cpra, const VariantMetadataIndex
 	}
 
 	bool match_alleles = (parts.size() == 4);
-	string ref_match, alt_match;
-	if (match_alleles) {
-		ref_match = parts[2];
-		alt_match = parts[3];
-	}
-
-	for (idx_t i = 0; i < variants.variant_ct; i++) {
-		if (variants.GetChrom(i) == chrom && variants.GetPos(i) == static_cast<int32_t>(pos)) {
-			if (match_alleles) {
-				if (variants.GetRef(i) == ref_match && variants.GetAlt(i) == alt_match) {
-					return static_cast<uint32_t>(i);
-				}
-			} else {
-				return static_cast<uint32_t>(i);
-			}
-		}
-	}
-
-	throw InvalidInputException("%s: variant '%s' not found", func_name, cpra);
+	return ResolveByCpra(variants, parts[0], static_cast<int32_t>(pos), match_alleles ? &parts[2] : nullptr,
+	                     match_alleles ? &parts[3] : nullptr, cpra, func_name);
 }
 
 //! Resolve a single variant string (rsid or CPRA) to a variant index.
@@ -1245,24 +1454,12 @@ static uint32_t ResolveCpraStruct(const Value &val, const VariantMetadataIndex &
 	}
 
 	bool match_alleles = has_ref && has_alt;
-
-	for (idx_t i = 0; i < variants.variant_ct; i++) {
-		if (variants.GetChrom(i) == chrom && variants.GetPos(i) == pos) {
-			if (match_alleles) {
-				if (variants.GetRef(i) == ref_val && variants.GetAlt(i) == alt_val) {
-					return static_cast<uint32_t>(i);
-				}
-			} else {
-				return static_cast<uint32_t>(i);
-			}
-		}
-	}
-
 	string desc = chrom + ":" + std::to_string(pos);
 	if (match_alleles) {
 		desc += ":" + ref_val + ":" + alt_val;
 	}
-	throw InvalidInputException("%s: variant '%s' not found", func_name, desc);
+	return ResolveByCpra(variants, chrom, pos, match_alleles ? &ref_val : nullptr, match_alleles ? &alt_val : nullptr,
+	                     desc, func_name);
 }
 
 //! Resolve a range struct ({start, stop} with INTEGER or VARCHAR values) to variant indices.

--- a/src/plink_ld.cpp
+++ b/src/plink_ld.cpp
@@ -361,28 +361,20 @@ static unique_ptr<FunctionData> PlinkLdBind(ClientContext &context, TableFunctio
 
 	// --- Resolve pairwise variant indices ---
 	if (bind_data->mode == LdMode::PAIRWISE) {
-		// Look up variant1 by ID
-		bool found_a = false, found_b = false;
-		for (uint32_t i = 0; i < static_cast<uint32_t>(bind_data->variants.variant_ct); i++) {
-			auto vid = bind_data->variants.GetId(i);
-			if (vid == variant1_id) {
-				bind_data->pairwise_vidx_a = i;
-				found_a = true;
-			}
-			if (vid == variant2_id) {
-				bind_data->pairwise_vidx_b = i;
-				found_b = true;
-			}
-			if (found_a && found_b) {
-				break;
-			}
-		}
-		if (!found_a) {
+		// BuildVariantIdIndex handles both dense and sparse (pushdown) indexes,
+		// and is O(loaded subset size) — a single pass that's also faster than
+		// the previous double-ID search loop.
+		auto id_to_idx = BuildVariantIdIndex(bind_data->variants);
+		auto it_a = id_to_idx.find(variant1_id);
+		if (it_a == id_to_idx.end()) {
 			throw InvalidInputException("plink_ld: variant '%s' not found in .pvar", variant1_id);
 		}
-		if (!found_b) {
+		bind_data->pairwise_vidx_a = it_a->second;
+		auto it_b = id_to_idx.find(variant2_id);
+		if (it_b == id_to_idx.end()) {
 			throw InvalidInputException("plink_ld: variant '%s' not found in .pvar", variant2_id);
 		}
+		bind_data->pairwise_vidx_b = it_b->second;
 	}
 
 	// --- Register output columns ---

--- a/src/plink_score.cpp
+++ b/src/plink_score.cpp
@@ -346,12 +346,15 @@ static unique_ptr<FunctionData> PlinkScoreBind(ClientContext &context, TableFunc
 				                            "LIST(STRUCT(id VARCHAR, allele VARCHAR, weight DOUBLE))");
 			}
 
-			// Build variant ID → index map (respecting region filter)
+			// Build variant ID → file-row-vidx map restricted to the region.
+			// Iterating local indices (range is produced by ParseRegion in local
+			// space) and mapping through VidxForLocal keeps this correct in both
+			// dense and sparse VariantMetadataIndex modes.
 			unordered_map<string, uint32_t> variant_id_map;
-			for (uint32_t i = range_start; i < range_end; i++) {
-				auto vid = bind_data->variants.GetId(i);
+			for (uint32_t local = range_start; local < range_end; local++) {
+				const auto &vid = bind_data->variants.ids[local];
 				if (!vid.empty()) {
-					variant_id_map[vid] = i;
+					variant_id_map[vid] = bind_data->variants.VidxForLocal(local);
 				}
 			}
 

--- a/src/psam_reader.cpp
+++ b/src/psam_reader.cpp
@@ -50,8 +50,24 @@ static bool IsParentMissing(const string &val) {
 // ---------------------------------------------------------------------------
 
 void SampleInfo::EnsureIidMap(const string &source_label) {
-	if (!iid_to_idx.empty() || iids.empty()) {
-		return;
+	if (!iid_to_idx.empty()) {
+		return; // already built
+	}
+	if (iids.empty()) {
+		// iids was never populated — the caller took the count-only fast path
+		// (LoadSampleCount / parquet footer metadata) and is now asking for
+		// IID-keyed lookups. This is a bug in PfileBind's `needs_iids` decision:
+		// any call site that reaches EnsureIidMap must have triggered the full
+		// load. Surfacing this explicitly instead of a confusing downstream
+		// "sample 'X' not found" error.
+		if (sample_ct > 0) {
+			throw InternalException(
+			    "%s: IID lookup requested but IID strings were not loaded (bind chose the count-only "
+			    "fast path for %llu samples). This indicates PfileBind's needs_iids predicate missed "
+			    "a case that requires IID strings — please report.",
+			    source_label.c_str(), static_cast<unsigned long long>(sample_ct));
+		}
+		return; // genuinely empty psam (no samples)
 	}
 	iid_to_idx.reserve(iids.size());
 	for (idx_t i = 0; i < iids.size(); i++) {

--- a/src/psam_reader.cpp
+++ b/src/psam_reader.cpp
@@ -46,6 +46,25 @@ static bool IsParentMissing(const string &val) {
 // WHERE PHENO1 != '-9' if needed.
 
 // ---------------------------------------------------------------------------
+// SampleInfo lazy helpers
+// ---------------------------------------------------------------------------
+
+void SampleInfo::EnsureIidMap(const string &source_label) {
+	if (!iid_to_idx.empty() || iids.empty()) {
+		return;
+	}
+	iid_to_idx.reserve(iids.size());
+	for (idx_t i = 0; i < iids.size(); i++) {
+		auto inserted = iid_to_idx.emplace(iids[i], i);
+		if (!inserted.second) {
+			throw IOException("%s has duplicate IID '%s' (at sample %llu and %llu)", source_label.c_str(),
+			                  iids[i].c_str(), static_cast<unsigned long long>(inserted.first->second + 1),
+			                  static_cast<unsigned long long>(i + 1));
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
 // Line splitting utilities
 // ---------------------------------------------------------------------------
 
@@ -253,21 +272,13 @@ SampleInfo LoadSampleInfo(ClientContext &context, const string &path) {
 			                  fields.size(), iid_idx + 1);
 		}
 
-		const auto &iid = fields[iid_idx];
-
-		// Duplicate IIDs are invalid — downstream code (read_pgen) relies on
-		// iid_to_idx being a 1:1 mapping for sample subsetting
-		if (info.iid_to_idx.count(iid)) {
-			throw IOException("read_psam: file '%s' line %d has duplicate IID '%s' "
-			                  "(first seen at sample %d)",
-			                  path, i + 1, iid, info.iid_to_idx[iid] + 1);
-		}
-
-		info.iids.push_back(iid);
+		// iid_to_idx is built lazily (see SampleInfo::EnsureIidMap) — this
+		// avoids ~7M string-hash inserts at biobank scale when the query
+		// doesn't use IID-based sample lookups.
+		info.iids.push_back(fields[iid_idx]);
 		if (has_fid) {
 			info.fids.push_back(fields[fid_idx]);
 		}
-		info.iid_to_idx[iid] = info.iids.size() - 1;
 	}
 
 	info.sample_ct = info.iids.size();


### PR DESCRIPTION
## Summary

- Fixes ~8s bind delay for region-filtered `read_pfile` queries on biobank-scale data (7M samples × 1.5M variants → ~8000ms → ~4ms measured)
- Same shape projects to sub-100ms at the 170M imputation panel scale
- All 60 sqllogictests / 3675 assertions still pass

## What changed

The slow path was three structural problems, fixed in one commit:

1. **Per-cell `Value::GetValue().ToString()` in a loop** when reading parquet companions → replaced with `FlatVector::GetData<T>` via `UnifiedVectorFormat` for columnar copies.
2. **Synthesizing a `#CHROM\tPOS\t...` text buffer from parquet data and re-parsing it** → `VariantMetadataIndex` is now columnar (typed vectors `chroms`/`positions`/`ids`/`refs`/`alts`) with a `chrom_offsets` index for O(log N) region lookups and a sparse `vidx_map` mode for pushdown.
3. **Always materializing the full pvar + psam at bind time** → new `LoadVariantMetadataFromParquetRegion` issues `WHERE chrom = ? AND pos BETWEEN ? AND ?` with `file_row_number` so only matching rows are read; new `LoadSampleCount` uses parquet footer metadata when the query doesn't need IIDs; `iid_to_idx` is now lazy via `SampleInfo::EnsureIidMap()`.

Plus binary-search `ParseRegion` / `ResolveByCpra`, and an env-gated `PLINKING_BIND_PROFILE=1` timing probe header (zero overhead when off).

## Test plan

- [x] `make test` (60 tests / 3675 assertions pass)
- [x] Profiled bind on simulated 7M × 1.5M parquet companions: 8041 ms → 4 ms
- [x] Profiled bind on real `wes_chr10` (10K × 30K text companions): ~7 ms
- [x] Region + VARCHAR sample filter triggers lazy `EnsureIidMap` correctly
- [ ] Verify on real biobank dataset (deferred — pending access)
- [ ] Verify on 170M imputation panel scale (deferred — needs synthetic generation at that size)

🤖 Generated with [Claude Code](https://claude.com/claude-code)