### PR TITLE
feat: include_genotypes genotype filter + fast carrier queries

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,9 +101,11 @@ DuckDB extension for reading PLINK 2 genomics file formats in SQL.
 - Count filters work in all orient modes and in both `read_pfile` and `read_pgen`; variant/genotype orient filter at scan time, sample orient filters at bind time (before schema)
 - AF denominator is `2 * non_missing_samples` (matches plink_freq), not `2 * total_samples`
 - `STD_ARRAY_DECL(uint32_t, 4, genocounts)` for PgrGetCounts (pgenlib uses std::array, not C arrays)
-- `genotype_range := {min: 1, max: 2}` filters individual genotype values; uses PgrGetCounts for pre-decompression optimization (skip variant if no values in range); per-element NULLing for partial matches
-- `genotype_range` incompatible with `dosages := true`; domain [0, 2]
-- `GenotypeRangeResult` from `CheckGenotypeRange`: `any_pass` = skip variant entirely when false; `all_pass` = skip per-element check when true (existing -9 handling suffices)
+- `include_genotypes := ['het', 'hom_alt']` filters by hardcall category — canonical genotype filter. Categories: `hom_ref` (0), `het` (1), `hom_alt` (2), `missing` (-9). Case-insensitive, whitespace-trimmed; unknown labels error. Arbitrary (incl. non-contiguous, e.g. `['hom_ref','hom_alt']`) subsets. `missing` is a first-class category — selecting it retains missing genotypes/rows.
+- `genotype_range := {min: 1, max: 2}` is the numeric alias of `include_genotypes` (contiguous ranges only over {0,1,2}); optional `include_missing := true` field retains missing. Specifying both `include_genotypes` and `genotype_range` errors.
+- Both compile to `GenotypeRangeFilter` (`allowed[3]` mask + `include_missing`); all engine sites use `AllowsCall(dosage)` / `CheckGenotypeRange`. `include_genotypes`/`genotype_range` incompatible with `dosages := true`.
+- Filter semantics by orient (row grain differs): **variant** orient — keep variant if any sample matches (`any_pass`), per-element NULL out non-matching sample values; **genotype** orient — skip rows whose genotype doesn't match; **sample** orient — skip sample rows with no matching genotype (built as a `sample_keep` list at bind, scan iterates it so only surviving rows materialize), per-element NULL out for array/list/columns, and **counts/stats aggregate modes report TRUE counts** (out-of-range hardcalls are NOT nulled to -9, so they are never miscounted as `missing`).
+- `GenotypeRangeResult` from `CheckGenotypeRange`: `any_pass` = skip variant entirely when false (true when a selected category or, with `include_missing`, missing is present); `all_pass` = skip per-element check when true.
 
 ## Extension Config Options
 

--- a/README.md
+++ b/README.md
@@ -147,6 +147,13 @@ SELECT * FROM read_pfile('data/example', variants := ['rs1', 'rs2']);
 SELECT iid, genotype
 FROM read_pfile('data/example', orient := 'genotype',
     region := '1:10000-50000', samples := ['SAMPLE1']);
+
+-- Fast carrier lookup: subjects carrying an ALT allele at a variant.
+-- In sample orient the scan emits only the matching subjects (not one row
+-- per sample), so this stays cheap at millions of individuals.
+SELECT iid
+FROM read_pfile('data/example', orient := 'sample', genotypes := 'counts',
+    variants := ['rs1'], include_genotypes := ['het', 'hom_alt']);
 ```
 
 **Default mode output:** CHROM, POS, ID, REF, ALT, genotypes `ARRAY(TINYINT, N)` — same as `read_pgen`.
@@ -165,6 +172,10 @@ plus scalar `genotype` (TINYINT). One row per variant x sample combination.
 | `samples` | LIST(VARCHAR) or LIST(INTEGER) | Filter to specific samples by IID or 0-based index |
 | `variants` | LIST(VARCHAR) or LIST(INTEGER) | Filter to specific variants by ID or 0-based index |
 | `region` | VARCHAR | Filter to genomic region (`chr:start-end` or `chr`) |
+| `include_genotypes` | LIST(VARCHAR) | Filter by hardcall category: `'hom_ref'`, `'het'`, `'hom_alt'`, `'missing'` (sample orient drops non-matching subjects) |
+| `af_range` / `ac_range` | STRUCT(min, max) | Filter variants by allele frequency / count |
+
+See [Common Parameters](docs/common-parameters.md) for the full filter reference (`genotype_range` is the numeric alias of `include_genotypes`).
 
 ### `read_plink_vcf(path [, genotypes, phased, region, min_gq, min_dp, max_dp])`
 

--- a/docs/common-parameters.md
+++ b/docs/common-parameters.md
@@ -126,19 +126,69 @@ Can be combined with `af_range`.
 
 **Used by:** `read_pgen`, `read_pfile`
 
+## `include_genotypes`
+
+| Type | Default |
+|------|---------|
+| `LIST(VARCHAR)` | All genotypes |
+
+Filter by hardcall genotype category. This is the canonical genotype filter; the
+categories are `'hom_ref'` (0), `'het'` (1), `'hom_alt'` (2), and `'missing'`
+(no call). Names are case-insensitive and whitespace-trimmed; an unknown name is
+an error. Any subset is allowed, including **non-contiguous** ones a numeric range
+cannot express (e.g. `['hom_ref', 'hom_alt']`). `'missing'` is a first-class
+category — include it to keep no-call genotypes/rows, omit it to drop them.
+
+How the filter reduces to rows depends on `orient` (because the meaning of a row
+differs):
+
+- **`variant`** — keep a variant if any sample matches; non-matching sample
+  values are set to NULL in the positional output.
+- **`genotype`** — emit only the (variant × sample) rows whose genotype matches
+  (applies regardless of which columns are selected).
+- **`sample`** — emit only the samples that have at least one matching genotype,
+  so a carrier query materializes just the matching subjects. In `counts`/`stats`
+  modes the reported counts are the sample's **true** genotype distribution
+  (out-of-range calls are never miscounted as missing).
+
+```sql
+-- Subjects carrying an ALT allele at a variant (het OR hom-alt), fast:
+SELECT IID
+FROM read_pfile('cohort', orient := 'sample', genotypes := 'counts',
+                variants := ['rs12345'], include_genotypes := ['het', 'hom_alt']);
+
+-- Homozygous subjects (non-contiguous set {0, 2}):
+SELECT IID
+FROM read_pfile('cohort', orient := 'sample',
+                variants := ['rs12345'], include_genotypes := ['hom_ref', 'hom_alt']);
+
+-- Keep carriers OR no-call subjects:
+SELECT IID
+FROM read_pfile('cohort', orient := 'sample',
+                variants := ['rs12345'], include_genotypes := ['het', 'hom_alt', 'missing']);
+```
+
+Incompatible with `dosages := true`.
+
+**Used by:** `read_pgen`, `read_pfile`
+
 ## `genotype_range`
 
 | Type | Default |
 |------|---------|
-| `STRUCT(min TINYINT, max TINYINT)` | All genotype values |
+| `STRUCT(min TINYINT, max TINYINT [, include_missing BOOLEAN])` | All genotype values |
 
-Filter individual genotype values. Genotypes outside the range are set to NULL. The domain is [0, 2]. Uses `PgrGetCounts` for pre-decompression optimization: variants where no values fall in range are skipped entirely.
+Numeric alias of [`include_genotypes`](#include_genotypes) for **contiguous**
+ranges over the domain [0, 2]. `{min: 1, max: 2}` is equivalent to
+`include_genotypes := ['het', 'hom_alt']`. The optional `include_missing := true`
+field keeps no-call genotypes (equivalent to adding `'missing'`). Specifying both
+`genotype_range` and `include_genotypes` is an error.
 
 ```sql
 -- Only heterozygous calls (genotype = 1)
 SELECT * FROM read_pgen('data.pgen', genotype_range := {min: 1, max: 1});
 
--- Het and hom-alt calls only
+-- Het and hom-alt calls only (== include_genotypes := ['het', 'hom_alt'])
 SELECT * FROM read_pfile('data', genotype_range := {min: 1, max: 2});
 ```
 

--- a/docs/functions/read_pfile.md
+++ b/docs/functions/read_pfile.md
@@ -8,7 +8,8 @@ Read a complete PLINK 2 fileset (`.pgen` + `.pvar` + `.psam`) from a common pref
 read_pfile(prefix VARCHAR [, pgen := ..., pvar := ..., psam := ...,
            orient := ..., genotypes := ..., phased := ..., dosages := ...,
            samples := ..., variants := ..., region := ...,
-           af_range := ..., ac_range := ..., genotype_range := ...]) -> TABLE
+           af_range := ..., ac_range := ...,
+           include_genotypes := ..., genotype_range := ...]) -> TABLE
 ```
 
 ## Parameters
@@ -28,7 +29,8 @@ read_pfile(prefix VARCHAR [, pgen := ..., pvar := ..., psam := ...,
 | `region` | `VARCHAR` | All | Filter to genomic region (`chr:start-end`) |
 | `af_range` | `STRUCT(min DOUBLE, max DOUBLE)` | All | Filter variants by allele frequency range |
 | `ac_range` | `STRUCT(min INTEGER, max INTEGER)` | All | Filter variants by allele count range |
-| `genotype_range` | `STRUCT(min TINYINT, max TINYINT)` | All | Filter individual genotype values |
+| `include_genotypes` | `LIST(VARCHAR)` | All | Filter by hardcall category: `'hom_ref'`, `'het'`, `'hom_alt'`, `'missing'` (any subset; canonical genotype filter) |
+| `genotype_range` | `STRUCT(min TINYINT, max TINYINT [, include_missing BOOLEAN])` | All | Numeric alias of `include_genotypes` for contiguous ranges over [0, 2] |
 
 See [Common Parameters](../common-parameters.md) for details on `samples`, `region`, and filter parameters.
 
@@ -105,7 +107,7 @@ With `phased := true`, genotype elements change from `TINYINT` to `ARRAY(TINYINT
 
 ### Filter Pushdown
 
-`af_range` and `ac_range` filter variants by allele frequency or count using fast genotype counting (no decompression). `genotype_range` filters individual genotype values, setting non-matching values to NULL. See [Common Parameters](../common-parameters.md).
+`af_range` and `ac_range` filter variants by allele frequency or count using fast genotype counting (no decompression). `include_genotypes` (and its numeric alias `genotype_range`) filters by hardcall category — in `variant` orient it sets non-matching values to NULL; in `genotype` and `sample` orient it drops non-matching rows, so a carrier query in `sample` orient materializes only the matching subjects. See [Common Parameters](../common-parameters.md).
 
 ### Projection Pushdown
 

--- a/docs/functions/read_pgen.md
+++ b/docs/functions/read_pgen.md
@@ -7,7 +7,8 @@ Read PLINK 2 `.pgen` binary genotype files.
 ```sql
 read_pgen(path VARCHAR [, pvar := ..., psam := ..., samples := ...,
           genotypes := ..., phased := ..., dosages := ...,
-          af_range := ..., ac_range := ..., genotype_range := ...]) -> TABLE
+          af_range := ..., ac_range := ...,
+          include_genotypes := ..., genotype_range := ...]) -> TABLE
 ```
 
 ## Parameters
@@ -23,7 +24,8 @@ read_pgen(path VARCHAR [, pvar := ..., psam := ..., samples := ...,
 | `dosages` | `BOOLEAN` | `false` | Output dosage values |
 | `af_range` | `STRUCT(min DOUBLE, max DOUBLE)` | All | Filter variants by allele frequency |
 | `ac_range` | `STRUCT(min INTEGER, max INTEGER)` | All | Filter variants by allele count |
-| `genotype_range` | `STRUCT(min TINYINT, max TINYINT)` | All | Filter individual genotype values |
+| `include_genotypes` | `LIST(VARCHAR)` | All | Filter by hardcall category: `'hom_ref'`, `'het'`, `'hom_alt'`, `'missing'` (any subset; canonical genotype filter) |
+| `genotype_range` | `STRUCT(min TINYINT, max TINYINT [, include_missing BOOLEAN])` | All | Numeric alias of `include_genotypes` for contiguous ranges over [0, 2] |
 
 See [Common Parameters](../common-parameters.md) for details on `pvar`, `psam`, `samples`, and filter parameters.
 
@@ -71,7 +73,7 @@ Variant processing is parallelized across multiple threads. Each thread gets its
 
 ### Filter Pushdown
 
-`af_range` and `ac_range` filter variants by allele frequency or count using fast genotype counting (no decompression needed). `genotype_range` filters individual genotype values, setting non-matching values to NULL.
+`af_range` and `ac_range` filter variants by allele frequency or count using fast genotype counting (no decompression needed). `include_genotypes` (and its numeric alias `genotype_range`) filters by hardcall category (`'hom_ref'`, `'het'`, `'hom_alt'`, `'missing'`), setting non-matching values to NULL in the variant-orient output. See [Common Parameters](../common-parameters.md#include_genotypes).
 
 See [Common Parameters](../common-parameters.md) for details on filter parameters.
 

--- a/docs/guides/performance.md
+++ b/docs/guides/performance.md
@@ -68,7 +68,7 @@ This avoids reading genotype data for variants outside the region.
 
 ## Filter Pushdown
 
-The `af_range`, `ac_range`, and `genotype_range` parameters let you filter variants or genotype values before full decompression:
+The `af_range`, `ac_range`, `include_genotypes`, and `genotype_range` parameters let you filter variants or genotypes before full decompression:
 
 ```sql
 -- Skip variants outside MAF range (uses PgrGetCounts, no decompression)
@@ -77,10 +77,30 @@ SELECT * FROM read_pfile('biobank',
 
 -- Only keep heterozygous calls
 SELECT * FROM read_pgen('biobank.pgen',
-    genotype_range := {min: 1, max: 1});
+    include_genotypes := ['het']);
 ```
 
-`af_range` and `ac_range` use pgenlib's `PgrGetCounts` to count genotypes without decompressing, then skip variants that fail the filter. `genotype_range` also uses `PgrGetCounts` as a pre-check — if a variant has no genotypes in range, it is skipped entirely without decompression.
+`af_range` and `ac_range` use pgenlib's `PgrGetCounts` to count genotypes without decompressing, then skip variants that fail the filter. `include_genotypes` (and its numeric alias `genotype_range`) also uses `PgrGetCounts` as a pre-check — if a variant has no matching genotypes, it is skipped entirely without decompression.
+
+### Fast carrier lookups (subject IDs matching a genotype)
+
+To list the subjects matching a genotype at a variant, combine `orient := 'sample'`
+with `include_genotypes` so the scan emits **only the matching subjects** instead
+of one row per sample. At biobank scale (millions of individuals) this is the
+difference between materializing every subject and materializing just the carriers:
+
+```sql
+-- Subjects carrying an ALT allele at rs12345 (het or hom-alt)
+SELECT IID
+FROM read_pfile('biobank', orient := 'sample', genotypes := 'counts',
+                variants := ['rs12345'], include_genotypes := ['het', 'hom_alt']);
+```
+
+The row filter is evaluated during the scan, so only carrier rows are produced —
+a `WHERE` clause on the output cannot achieve this because the per-subject counts
+are computed inside the table function. The same works in `genotype` orient
+(one row per matching variant × subject), and the filter applies whether or not
+the genotype column itself is selected.
 
 ## Sample Subsetting
 

--- a/docs/planning/P4-003-genotype-filter-pushdown
+++ b/docs/planning/P4-003-genotype-filter-pushdown
@@ -172,21 +172,30 @@ available from the .pgen header.
 
 DuckDB table function schemas are fixed at bind time. This means column-level
 skipping is architecturally impossible — you cannot remove a column during
-scan. Therefore, `genotype_range` **nulls out** values in all multi-sample
-output formats and only **skips rows** in genotype orient (where each row is
-a single scalar observation).
+scan. So along the *variant* axis the filter **nulls out** element values, and
+along any axis where a **row** is one sample/observation it also **skips rows**.
 
-| Orient | ARRAY/LIST (positional) | COLUMNS (named) | genotype orient (scalar) |
-|--------|------------------------|-----------------|------------------------|
-| **variant** | Null out elements | Null out values | — |
-| **sample** | Null out elements | Null out values | — |
-| **genotype** | — | — | Skip rows |
+> **Update (`include_genotypes` / row-skip):** the original design skipped rows
+> only in genotype orient and left every sample row in sample orient (nulling
+> out the variant axis). Sample orient now also **skips rows**: a sample is
+> emitted only if it has at least one matching genotype (or a matching
+> `missing` when selected), built as a `sample_keep` list at bind time so only
+> surviving rows materialize. In **counts/stats** aggregate modes the filter is
+> purely a row filter — out-of-range hardcalls are NOT nulled to `-9` (which
+> would miscount them as `missing`); the reported counts are the true genotype
+> distribution of each surviving sample.
+
+| Orient | ARRAY/LIST (positional) | COLUMNS (named) | COUNTS/STATS (aggregate) | genotype orient (scalar) |
+|--------|------------------------|-----------------|--------------------------|--------------------------|
+| **variant** | Null out elements | Null out values | true counts | — |
+| **sample** | Null out elements + skip empty rows | Null out values + skip empty rows | true counts + skip empty rows | — |
+| **genotype** | — | — | — | Skip rows |
 
 **Null out**: out-of-range genotype values replaced with NULL. Array/list
 length preserved, positional alignment maintained.
 
-**Skip rows**: in genotype orient, each row is one observation. Rows with
-out-of-range genotype values are simply not emitted.
+**Skip rows**: a row that is one sample/observation with no matching genotype
+is simply not emitted.
 
 **af_range / ac_range** always skip entire variants regardless of output
 format — the variant either passes or doesn't. In positional modes

--- a/src/include/plink_common.hpp
+++ b/src/include/plink_common.hpp
@@ -388,8 +388,11 @@ struct CountFilter {
 
 //! Parse a STRUCT value into a RangeFilter with optional min/max fields.
 //! valid_min/valid_max define the legal range for values (e.g. 0.0-1.0 for AF).
+//! When include_missing_out is non-null, an "include_missing" BOOLEAN field is
+//! also accepted and written out (used by genotype_range); otherwise that field
+//! name is rejected like any other unknown field.
 RangeFilter ParseRangeFilter(const Value &val, const string &param_name, double valid_min, double valid_max,
-                             const string &func_name);
+                             const string &func_name, bool *include_missing_out = nullptr);
 
 //! Check if a variant passes count-based filters given its genotype counts.
 //! genocounts: [hom_ref, het, hom_alt, missing] from PgrGetCounts.
@@ -405,12 +408,44 @@ struct GenotypeRangeResult {
 	bool all_pass; // every non-missing sample has value in [min, max]
 };
 
+//! Selects which hardcall genotype categories a genotype filter keeps.
+//! allowed[0..2] gate hom_ref / het / hom_alt (ALT dosage 0/1/2); include_missing
+//! gates missing (-9). Populated from either the `genotype_range` (numeric alias)
+//! or `include_genotypes` (named-category) parameter — both compile to this mask,
+//! so all engine sites use a single predicate.
 struct GenotypeRangeFilter {
-	RangeFilter range; // reuses Phase 1 RangeFilter
 	bool active = false;
+	bool allowed[3] = {false, false, false}; // hom_ref, het, hom_alt
+	bool include_missing = false;
+
+	//! True when a hardcall ALT dosage (0/1/2, or a phased diploid sum) is a
+	//! selected category. Non-integer or out-of-domain values never match. Takes a
+	//! double so it slots in where the old RangeFilter::Passes(double) was called.
+	bool AllowsCall(double dosage) const {
+		int v = static_cast<int>(dosage);
+		if (v < 0 || v > 2 || static_cast<double>(v) != dosage) {
+			return false;
+		}
+		return allowed[v];
+	}
+
+	//! Populate the mask from a numeric [min,max] range over {0,1,2} (the
+	//! `genotype_range` alias). include_missing comes from the range's own field.
+	void SetFromRange(const RangeFilter &range, bool inc_missing) {
+		for (int g = 0; g <= 2; g++) {
+			allowed[g] = range.Passes(static_cast<double>(g));
+		}
+		include_missing = inc_missing;
+		active = range.active;
+	}
 };
 
-GenotypeRangeResult CheckGenotypeRange(const RangeFilter &filter, const STD_ARRAY_REF(uint32_t, 4) genocounts);
+GenotypeRangeResult CheckGenotypeRange(const GenotypeRangeFilter &filter, const STD_ARRAY_REF(uint32_t, 4) genocounts);
+
+//! Parse an `include_genotypes` LIST of category labels into a GenotypeRangeFilter.
+//! Accepts 'hom_ref', 'het', 'hom_alt', 'missing' (case-insensitive). Empty list
+//! is a no-op (inactive). Throws on unknown labels.
+void ParseIncludeGenotypes(const Value &val, GenotypeRangeFilter &out, const string &func_name);
 
 //! Combined pre-decompression filter check: count filter + genotype range.
 //! Returns: skip=true → skip variant entirely. skip=false → variant passes,

--- a/src/pfile_reader.cpp
+++ b/src/pfile_reader.cpp
@@ -7,9 +7,11 @@
 
 #include "duckdb/common/file_system.hpp"
 #include "duckdb/common/string_util.hpp"
+#include "duckdb/common/types/column/column_data_collection.hpp"
 #include "duckdb/common/vector_operations/vector_operations.hpp"
 #include "duckdb/main/connection.hpp"
 #include "duckdb/main/database.hpp"
+#include "duckdb/main/materialized_query_result.hpp"
 
 #include <pgenlib_read.h>
 #include <pgenlib_ffi_support.h>
@@ -95,14 +97,31 @@ static RegionFilter ParseRegion(const string &region_str) {
 //! Extended sample info for genotype orient mode: includes all psam columns.
 struct PfileSampleMetadata {
 	PsamHeaderInfo header;
-	//! All data rows from the .psam/.fam, in file order.
-	//! Each inner vector has one field per column.
+	//! All data rows from the .psam/.fam, in file order (TEXT path).
+	//! Each inner vector has one field per column. Empty when column_data is set.
 	vector<vector<string>> rows;
+
+	//! Native columnar storage of the sample rows (parquet/non-native source path).
+	//! When set, the scan reads NON-id psam column values from here instead of
+	//! `rows`, avoiding materializing every cell as a std::string. IID/FID come from
+	//! SampleInfo::iids/fids (extracted once at load). Row order matches file order;
+	//! column order matches `header.column_names`.
+	unique_ptr<ColumnDataCollection> column_data;
+	//! Cumulative starting row of each column_data chunk (size ChunkCount()+1), so a
+	//! file-order row maps to (chunk, offset) — CDC chunks are not 2048-aligned.
+	vector<idx_t> chunk_start_row;
+	//! IID / FID column positions in the header (for the column_data path).
+	idx_t iid_col_idx = DConstants::INVALID_INDEX;
+	idx_t fid_col_idx = DConstants::INVALID_INDEX;
 
 	//! Index of SEX column in the header (DConstants::INVALID_INDEX if absent)
 	idx_t sex_col_idx = DConstants::INVALID_INDEX;
 	//! Indices of PAT/MAT columns for special missing-value handling
 	vector<idx_t> parent_col_indices;
+
+	bool HasColumnData() const {
+		return column_data != nullptr;
+	}
 };
 
 //! Missing value sentinels (same as psam_reader)
@@ -153,49 +172,64 @@ static PfileSampleMetadata LoadPfileSampleMetadataFromSource(ClientContext &cont
 
 	bool has_fid = (fid_idx != DConstants::INVALID_INDEX);
 
-	unique_ptr<DataChunk> chunk;
-	while ((chunk = result->Fetch()) != nullptr && chunk->size() > 0) {
-		const idx_t n = chunk->size();
-		const idx_t ncol = chunk->ColumnCount();
+	// Retain the query result's native columnar data instead of materializing every
+	// cell as a std::string. The scan reads psam column values directly from this
+	// ColumnDataCollection (see EmitSampleMetadataColumn); only the IID/FID columns
+	// are copied out into sample_info here, since those drive subsetting and column
+	// naming. This is the difference between ~3.5s and ~1s at 10M samples.
+	meta.iid_col_idx = iid_idx;
+	meta.fid_col_idx = fid_idx;
 
-		// Extract each column vectorized instead of boxing every cell with
-		// chunk->GetValue() (which allocates a Value per cell — the dominant cost
-		// at millions of rows). Cast each non-VARCHAR column to VARCHAR once, then
-		// read string_t directly through a UnifiedVectorFormat.
-		vector<Vector> cast_cols;    // owns cast results; must outlive `formats`
-		cast_cols.reserve(ncol);
-		vector<UnifiedVectorFormat> formats(ncol);
-		for (idx_t col = 0; col < ncol; col++) {
-			cast_cols.emplace_back(LogicalType::VARCHAR);
-			if (chunk->data[col].GetType().id() == LogicalTypeId::VARCHAR) {
-				chunk->data[col].ToUnifiedFormat(n, formats[col]);
-			} else {
-				VectorOperations::Cast(context, chunk->data[col], cast_cols[col], n);
-				cast_cols[col].ToUnifiedFormat(n, formats[col]);
+	auto &materialized = *result;
+	auto &collection = materialized.Collection();
+	const idx_t row_ct = collection.Count();
+	sample_info_out.iids.reserve(row_ct);
+	if (has_fid) {
+		sample_info_out.fids.reserve(row_ct);
+	}
+
+	// One vectorized scan: extract IID (and FID) as std::string (these drive
+	// subsetting + IID output) and record cumulative chunk offsets so the scan can
+	// map a file-order row to (chunk, offset) for the other columns. The scan's
+	// chunk boundaries match the physical CDC chunks used by FetchChunk.
+	vector<column_t> id_cols;
+	id_cols.push_back(iid_idx);
+	if (has_fid) {
+		id_cols.push_back(fid_idx);
+	}
+	ColumnDataScanState scan_state;
+	collection.InitializeScan(scan_state, id_cols);
+	DataChunk id_chunk;
+	collection.InitializeScanChunk(scan_state, id_chunk);
+	meta.chunk_start_row.push_back(0);
+	idx_t running = 0;
+	while (collection.Scan(scan_state, id_chunk)) {
+		const idx_t n = id_chunk.size();
+		auto extract = [&](idx_t chunk_col, vector<string> &out) {
+			Vector varchar_vec(LogicalType::VARCHAR);
+			Vector *src = &id_chunk.data[chunk_col];
+			if (src->GetType().id() != LogicalTypeId::VARCHAR) {
+				VectorOperations::Cast(context, *src, varchar_vec, n);
+				src = &varchar_vec;
 			}
-		}
-
-		for (idx_t row = 0; row < n; row++) {
-			vector<string> fields(ncol);
-			for (idx_t col = 0; col < ncol; col++) {
-				auto &fmt = formats[col];
+			UnifiedVectorFormat fmt;
+			src->ToUnifiedFormat(n, fmt);
+			auto data = UnifiedVectorFormat::GetData<string_t>(fmt);
+			for (idx_t row = 0; row < n; row++) {
 				idx_t vidx = fmt.sel->get_index(row);
-				if (fmt.validity.RowIsValid(vidx)) {
-					fields[col] = UnifiedVectorFormat::GetData<string_t>(fmt)[vidx].GetString();
-				}
+				out.push_back(fmt.validity.RowIsValid(vidx) ? data[vidx].GetString() : string());
 			}
-
-			// iid_to_idx is lazy (see SampleInfo::EnsureIidMap).
-			sample_info_out.iids.push_back(fields[iid_idx]);
-			if (has_fid) {
-				sample_info_out.fids.push_back(fields[fid_idx]);
-			}
-
-			meta.rows.push_back(std::move(fields));
+		};
+		extract(0, sample_info_out.iids);
+		if (has_fid) {
+			extract(1, sample_info_out.fids);
 		}
+		running += n;
+		meta.chunk_start_row.push_back(running);
 	}
 
 	sample_info_out.sample_ct = sample_info_out.iids.size();
+	meta.column_data = materialized.TakeCollection();
 	return meta;
 }
 
@@ -459,6 +493,11 @@ struct PfileLocalState : public LocalTableFunctionState {
 	bool batch_variant_loaded = false;      // genotypes decoded for current variant in batch
 	bool geno_range_all_pass = true;        // per-variant flag for genotype_range optimization
 	bool batch_exhausted = true;            // true initially to trigger first batch claim
+
+	// Per-thread cache of one column_data chunk for reading non-id psam columns at
+	// scan time (sample_metadata.column_data path). Populated lazily via FetchChunk.
+	DataChunk psam_chunk;
+	idx_t psam_chunk_idx = DConstants::INVALID_INDEX;
 
 	~PfileLocalState() {
 		if (initialized) {
@@ -2253,6 +2292,61 @@ static void FillSampleMetadataValue(Vector &vec, idx_t row_idx, const string &va
 	}
 }
 
+//! Emit one psam column value for a sample into an output vector, from whichever
+//! metadata representation is populated:
+//!  - text path: the std::string in PfileSampleMetadata::rows.
+//!  - column_data path: IID/FID come from the pre-extracted SampleInfo strings;
+//!    other columns are read from the retained ColumnDataCollection via a
+//!    per-thread cached chunk (mapping file-order row -> (chunk, offset) through
+//!    chunk_start_row). Value semantics go through FillSampleMetadataValue so the
+//!    SEX/PAT/MAT/missing handling is identical to the text path.
+static void EmitSampleMetadataColumn(const PfileBindData &bind_data, PfileLocalState &lstate, Vector &out_vec,
+                                     idx_t out_row, idx_t sample_file_idx, idx_t psam_col_idx) {
+	auto &meta = bind_data.sample_metadata;
+
+	if (!meta.HasColumnData()) {
+		if (sample_file_idx < meta.rows.size() && psam_col_idx < meta.rows[sample_file_idx].size()) {
+			FillSampleMetadataValue(out_vec, out_row, meta.rows[sample_file_idx][psam_col_idx], psam_col_idx, meta);
+		} else {
+			FlatVector::SetNull(out_vec, out_row, true);
+		}
+		return;
+	}
+
+	// IID / FID: use the strings already extracted at load.
+	if (psam_col_idx == meta.iid_col_idx) {
+		const auto &iids = bind_data.sample_info.iids;
+		FillSampleMetadataValue(out_vec, out_row, sample_file_idx < iids.size() ? iids[sample_file_idx] : string(),
+		                        psam_col_idx, meta);
+		return;
+	}
+	if (psam_col_idx == meta.fid_col_idx) {
+		const auto &fids = bind_data.sample_info.fids;
+		FillSampleMetadataValue(out_vec, out_row, sample_file_idx < fids.size() ? fids[sample_file_idx] : string(),
+		                        psam_col_idx, meta);
+		return;
+	}
+
+	// Other columns: locate the chunk covering this row and read it (cast to string
+	// through Value — only hit when a non-id psam column is actually projected).
+	const auto &starts = meta.chunk_start_row;
+	if (starts.size() < 2 || sample_file_idx >= starts.back()) {
+		FlatVector::SetNull(out_vec, out_row, true);
+		return;
+	}
+	idx_t chunk_idx = (idx_t)(std::upper_bound(starts.begin(), starts.end(), sample_file_idx) - starts.begin()) - 1;
+	if (chunk_idx != lstate.psam_chunk_idx) {
+		if (lstate.psam_chunk.ColumnCount() == 0) {
+			meta.column_data->InitializeScanChunk(lstate.psam_chunk);
+		}
+		meta.column_data->FetchChunk(chunk_idx, lstate.psam_chunk);
+		lstate.psam_chunk_idx = chunk_idx;
+	}
+	idx_t local = sample_file_idx - starts[chunk_idx];
+	Value v = lstate.psam_chunk.data[psam_col_idx].GetValue(local);
+	FillSampleMetadataValue(out_vec, out_row, v.IsNull() ? string() : v.ToString(), psam_col_idx, meta);
+}
+
 static void PfileTidyScan(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
 	auto &bind_data = data_p.bind_data->Cast<PfileBindData>();
 	auto &gstate = data_p.global_state->Cast<PfileGlobalState>();
@@ -2491,17 +2585,7 @@ static void PfileTidyScan(ClientContext &context, TableFunctionInput &data_p, Da
 					idx_t sample_col_rel = file_col - bind_data.geno_sample_col_start;
 					idx_t psam_col_idx = bind_data.geno_sample_col_to_psam_col[sample_col_rel];
 
-					if (sample_file_idx < bind_data.sample_metadata.rows.size()) {
-						auto &sample_row = bind_data.sample_metadata.rows[sample_file_idx];
-						if (psam_col_idx < sample_row.size()) {
-							FillSampleMetadataValue(vec, rows_emitted, sample_row[psam_col_idx], psam_col_idx,
-							                        bind_data.sample_metadata);
-						} else {
-							FlatVector::SetNull(vec, rows_emitted, true);
-						}
-					} else {
-						FlatVector::SetNull(vec, rows_emitted, true);
-					}
+					EmitSampleMetadataColumn(bind_data, lstate, vec, rows_emitted, sample_file_idx, psam_col_idx);
 				}
 			}
 
@@ -2527,6 +2611,7 @@ static void PfileTidyScan(ClientContext &context, TableFunctionInput &data_p, Da
 static void PfileSampleOrientScan(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
 	auto &bind_data = data_p.bind_data->Cast<PfileBindData>();
 	auto &gstate = data_p.global_state->Cast<PfileGlobalState>();
+	auto &lstate = data_p.local_state->Cast<PfileLocalState>();
 
 	auto &column_ids = gstate.column_ids;
 	uint32_t total_samples = gstate.total_count;
@@ -2805,17 +2890,7 @@ static void PfileSampleOrientScan(ClientContext &context, TableFunctionInput &da
 					// Sample metadata column
 					idx_t psam_col_idx = bind_data.sample_orient_col_to_psam_col[file_col];
 
-					if (sample_file_idx < bind_data.sample_metadata.rows.size()) {
-						auto &sample_row = bind_data.sample_metadata.rows[sample_file_idx];
-						if (psam_col_idx < sample_row.size()) {
-							FillSampleMetadataValue(vec, rows_emitted, sample_row[psam_col_idx], psam_col_idx,
-							                        bind_data.sample_metadata);
-						} else {
-							FlatVector::SetNull(vec, rows_emitted, true);
-						}
-					} else {
-						FlatVector::SetNull(vec, rows_emitted, true);
-					}
+					EmitSampleMetadataColumn(bind_data, lstate, vec, rows_emitted, sample_file_idx, psam_col_idx);
 				}
 			}
 

--- a/src/pfile_reader.cpp
+++ b/src/pfile_reader.cpp
@@ -1588,8 +1588,8 @@ static unique_ptr<GlobalTableFunctionState> PfileInitGlobal(ClientContext &conte
 			state->need_genotypes = true;
 		}
 	} else if (bind_data.orient_mode == OrientMode::SAMPLE) {
-		state->total_count =
-		    bind_data.has_sample_keep ? static_cast<uint32_t>(bind_data.sample_keep.size()) : bind_data.OutputSampleCt();
+		state->total_count = bind_data.has_sample_keep ? static_cast<uint32_t>(bind_data.sample_keep.size())
+		                                               : bind_data.OutputSampleCt();
 		// Check if genotypes column(s) are projected
 		state->need_genotypes = false;
 		for (auto col_id : input.column_ids) {
@@ -1941,9 +1941,8 @@ static void PfileDefaultScan(ClientContext &context, TableFunctionInput &data_p,
 								}
 							} else {
 								int8_t geno = lstate.genotype_bytes[sample_pos];
-								if (geno == -9 ||
-								    (bind_data.genotype_filter.active && !geno_range_all_pass &&
-								     !bind_data.genotype_filter.AllowsCall(static_cast<double>(geno)))) {
+								if (geno == -9 || (bind_data.genotype_filter.active && !geno_range_all_pass &&
+								                   !bind_data.genotype_filter.AllowsCall(static_cast<double>(geno)))) {
 									FlatVector::SetNull(vec, rows_emitted, true);
 								} else {
 									FlatVector::GetData<int8_t>(vec)[rows_emitted] = geno;
@@ -1986,9 +1985,8 @@ static void PfileDefaultScan(ClientContext &context, TableFunctionInput &data_p,
 								}
 							} else {
 								int8_t geno = lstate.genotype_bytes[s];
-								if (geno == -9 ||
-								    (bind_data.genotype_filter.active && !geno_range_all_pass &&
-								     !bind_data.genotype_filter.AllowsCall(static_cast<double>(geno)))) {
+								if (geno == -9 || (bind_data.genotype_filter.active && !geno_range_all_pass &&
+								                   !bind_data.genotype_filter.AllowsCall(static_cast<double>(geno)))) {
 									FlatVector::SetNull(child_vec, rows_emitted, true);
 								} else {
 									FlatVector::GetData<int8_t>(child_vec)[rows_emitted] = geno;
@@ -2081,8 +2079,8 @@ static void PfileDefaultScan(ClientContext &context, TableFunctionInput &data_p,
 								idx_t allele_base = pair_idx * 2;
 								int8_t a1 = lstate.phased_pairs[s * 2];
 								int8_t a2 = lstate.phased_pairs[s * 2 + 1];
-								if (a1 == -9 || (!geno_range_all_pass && !bind_data.genotype_filter.AllowsCall(
-								                                             static_cast<double>(a1 + a2)))) {
+								if (a1 == -9 || (!geno_range_all_pass &&
+								                 !bind_data.genotype_filter.AllowsCall(static_cast<double>(a1 + a2)))) {
 									pair_validity.SetInvalid(pair_idx);
 									allele_data[allele_base] = 0;
 									allele_data[allele_base + 1] = 0;
@@ -2104,8 +2102,8 @@ static void PfileDefaultScan(ClientContext &context, TableFunctionInput &data_p,
 								idx_t allele_base = pair_idx * 2;
 								int8_t a1 = lstate.phased_pairs[s * 2];
 								int8_t a2 = lstate.phased_pairs[s * 2 + 1];
-								if (a1 == -9 || (!geno_range_all_pass && !bind_data.genotype_filter.AllowsCall(
-								                                             static_cast<double>(a1 + a2)))) {
+								if (a1 == -9 || (!geno_range_all_pass &&
+								                 !bind_data.genotype_filter.AllowsCall(static_cast<double>(a1 + a2)))) {
 									pair_validity.SetInvalid(pair_idx);
 									allele_data[allele_base] = 0;
 									allele_data[allele_base + 1] = 0;
@@ -2173,8 +2171,8 @@ static void PfileDefaultScan(ClientContext &context, TableFunctionInput &data_p,
 							idx_t base = rows_emitted * array_size;
 							for (idx_t s = 0; s < array_size; s++) {
 								int8_t geno = lstate.genotype_bytes[s];
-								if (geno == -9 || (!geno_range_all_pass && !bind_data.genotype_filter.AllowsCall(
-								                                               static_cast<double>(geno)))) {
+								if (geno == -9 || (!geno_range_all_pass &&
+								                   !bind_data.genotype_filter.AllowsCall(static_cast<double>(geno)))) {
 									child_validity.SetInvalid(base + s);
 									child_data[base + s] = 0;
 								} else {
@@ -2189,8 +2187,8 @@ static void PfileDefaultScan(ClientContext &context, TableFunctionInput &data_p,
 							auto &child_validity = FlatVector::Validity(child);
 							for (idx_t s = 0; s < output_sample_ct; s++) {
 								int8_t geno = lstate.genotype_bytes[s];
-								if (geno == -9 || (!geno_range_all_pass && !bind_data.genotype_filter.AllowsCall(
-								                                               static_cast<double>(geno)))) {
+								if (geno == -9 || (!geno_range_all_pass &&
+								                   !bind_data.genotype_filter.AllowsCall(static_cast<double>(geno)))) {
 									child_validity.SetInvalid(list_offset + s);
 									child_data[list_offset + s] = 0;
 								} else {
@@ -2221,9 +2219,8 @@ static void PfileDefaultScan(ClientContext &context, TableFunctionInput &data_p,
 								}
 							} else {
 								int8_t geno = lstate.genotype_bytes[sample_pos];
-								if (geno == -9 ||
-								    (bind_data.genotype_filter.active && !geno_range_all_pass &&
-								     !bind_data.genotype_filter.AllowsCall(static_cast<double>(geno)))) {
+								if (geno == -9 || (bind_data.genotype_filter.active && !geno_range_all_pass &&
+								                   !bind_data.genotype_filter.AllowsCall(static_cast<double>(geno)))) {
 									FlatVector::SetNull(vec, rows_emitted, true);
 								} else {
 									FlatVector::GetData<int8_t>(vec)[rows_emitted] = geno;

--- a/src/pfile_reader.cpp
+++ b/src/pfile_reader.cpp
@@ -7,6 +7,7 @@
 
 #include "duckdb/common/file_system.hpp"
 #include "duckdb/common/string_util.hpp"
+#include "duckdb/common/vector_operations/vector_operations.hpp"
 #include "duckdb/main/connection.hpp"
 #include "duckdb/main/database.hpp"
 
@@ -154,11 +155,34 @@ static PfileSampleMetadata LoadPfileSampleMetadataFromSource(ClientContext &cont
 
 	unique_ptr<DataChunk> chunk;
 	while ((chunk = result->Fetch()) != nullptr && chunk->size() > 0) {
-		for (idx_t row = 0; row < chunk->size(); row++) {
-			vector<string> fields;
-			for (idx_t col = 0; col < chunk->ColumnCount(); col++) {
-				auto val = chunk->GetValue(col, row);
-				fields.push_back(val.IsNull() ? "" : val.ToString());
+		const idx_t n = chunk->size();
+		const idx_t ncol = chunk->ColumnCount();
+
+		// Extract each column vectorized instead of boxing every cell with
+		// chunk->GetValue() (which allocates a Value per cell — the dominant cost
+		// at millions of rows). Cast each non-VARCHAR column to VARCHAR once, then
+		// read string_t directly through a UnifiedVectorFormat.
+		vector<Vector> cast_cols;    // owns cast results; must outlive `formats`
+		cast_cols.reserve(ncol);
+		vector<UnifiedVectorFormat> formats(ncol);
+		for (idx_t col = 0; col < ncol; col++) {
+			cast_cols.emplace_back(LogicalType::VARCHAR);
+			if (chunk->data[col].GetType().id() == LogicalTypeId::VARCHAR) {
+				chunk->data[col].ToUnifiedFormat(n, formats[col]);
+			} else {
+				VectorOperations::Cast(context, chunk->data[col], cast_cols[col], n);
+				cast_cols[col].ToUnifiedFormat(n, formats[col]);
+			}
+		}
+
+		for (idx_t row = 0; row < n; row++) {
+			vector<string> fields(ncol);
+			for (idx_t col = 0; col < ncol; col++) {
+				auto &fmt = formats[col];
+				idx_t vidx = fmt.sel->get_index(row);
+				if (fmt.validity.RowIsValid(vidx)) {
+					fields[col] = UnifiedVectorFormat::GetData<string_t>(fmt)[vidx].GetString();
+				}
 			}
 
 			// iid_to_idx is lazy (see SampleInfo::EnsureIidMap).
@@ -533,18 +557,11 @@ static unique_ptr<FunctionData> PfileBind(ClientContext &context, TableFunctionB
 	}
 
 	if (bind_data->psam_path.empty()) {
-		if (!prefix.empty()) {
-			for (auto &ext : {".psam", ".fam"}) {
-				auto candidate = prefix + ext;
-				if (fs.FileExists(candidate)) {
-					bind_data->psam_path = candidate;
-					break;
-				}
-			}
-		}
-		if (bind_data->psam_path.empty()) {
-			bind_data->psam_path = FindCompanionFileWithParquet(context, fs, bind_data->pgen_path, {".psam", ".fam"});
-		}
+		// Prefer a .psam.parquet companion over the text .psam/.fam when present
+		// (honors plinking_use_parquet_companions) — mirrors the .pvar resolution
+		// above. Resolve from the prefix when given, else from the pgen path.
+		string psam_base = prefix.empty() ? bind_data->pgen_path : prefix + ".pgen";
+		bind_data->psam_path = FindCompanionFileWithParquet(context, fs, psam_base, {".psam", ".fam"});
 		if (bind_data->psam_path.empty()) {
 			throw InvalidInputException("read_pfile: cannot find .psam or .fam file for '%s' "
 			                            "(use psam := 'path' to specify explicitly)",

--- a/src/pfile_reader.cpp
+++ b/src/pfile_reader.cpp
@@ -316,6 +316,13 @@ struct PfileBindData : public TableFunctionData {
 	// Dosage variant of genotype_matrix (-9.0 = missing)
 	vector<vector<double>> dosage_matrix;
 
+	// Sample-orient row-level genotype_range filter: output sample positions that
+	// survive the filter (a sample is kept iff at least one of its genotypes
+	// satisfies genotype_range, or is missing when include_missing is set).
+	// When has_sample_keep is false, all OutputSampleCt() samples are emitted.
+	bool has_sample_keep = false;
+	vector<uint32_t> sample_keep;
+
 	// Sample-orient column layout
 	// Sample metadata columns start at index 0, genotypes column is last
 	idx_t sample_orient_genotypes_col = 0; // computed in bind (ARRAY/LIST only)
@@ -833,16 +840,29 @@ static unique_ptr<FunctionData> PfileBind(ClientContext &context, TableFunctionB
 		}
 	}
 
-	// --- Parse genotype_range filter ---
+	// --- Parse genotype filter: include_genotypes (canonical) or genotype_range (alias) ---
 	{
+		auto ig_it = input.named_parameters.find("include_genotypes");
 		auto gr_it = input.named_parameters.find("genotype_range");
-		if (gr_it != input.named_parameters.end()) {
+		bool has_ig = ig_it != input.named_parameters.end();
+		bool has_gr = gr_it != input.named_parameters.end();
+		if (has_ig && has_gr) {
+			throw InvalidInputException(
+			    "read_pfile: specify only one of include_genotypes or genotype_range (genotype_range is the numeric "
+			    "alias of include_genotypes)");
+		}
+		if (has_ig || has_gr) {
 			if (bind_data->include_dosages) {
-				throw InvalidInputException("read_pfile: genotype_range is incompatible with dosages := true");
+				throw InvalidInputException("read_pfile: %s is incompatible with dosages := true",
+				                            has_ig ? "include_genotypes" : "genotype_range");
 			}
-			bind_data->genotype_filter.range =
-			    ParseRangeFilter(gr_it->second, "genotype_range", 0.0, 2.0, "read_pfile");
-			bind_data->genotype_filter.active = bind_data->genotype_filter.range.active;
+		}
+		if (has_ig) {
+			ParseIncludeGenotypes(ig_it->second, bind_data->genotype_filter, "read_pfile");
+		} else if (has_gr) {
+			bool inc_missing = false;
+			RangeFilter range = ParseRangeFilter(gr_it->second, "genotype_range", 0.0, 2.0, "read_pfile", &inc_missing);
+			bind_data->genotype_filter.SetFromRange(range, inc_missing);
 		}
 	}
 
@@ -1245,6 +1265,22 @@ static unique_ptr<FunctionData> PfileBind(ClientContext &context, TableFunctionB
 		} else {
 			bind_data->genotype_matrix.resize(effective_variant_ct);
 		}
+
+		// Row-level genotype_range accumulators (sample orient): track, per output
+		// sample, whether it has any in-range genotype and any missing genotype
+		// across the effective variants. Computed from TRUE genotype values, before
+		// any per-element null-out, so aggregate counts and the keep decision are
+		// not confused by the -9 sentinel. dosages are incompatible with
+		// genotype_range (rejected at parse time), so only the non-dosage paths
+		// populate these.
+		const bool row_filter_active = bind_data->genotype_filter.active && !bind_data->include_dosages;
+		vector<uint8_t> sample_in_range;
+		vector<uint8_t> sample_has_missing;
+		if (row_filter_active) {
+			sample_in_range.assign(output_sample_ct, 0);
+			sample_has_missing.assign(output_sample_ct, 0);
+		}
+
 		for (uint32_t ev = 0; ev < effective_variant_ct; ev++) {
 			uint32_t vidx = bind_data->has_effective_variant_list ? bind_data->effective_variant_indices[ev] : ev;
 
@@ -1289,13 +1325,25 @@ static unique_ptr<FunctionData> PfileBind(ClientContext &context, TableFunctionB
 				plink2::GenoarrToBytesMinus9(genovec_buf2.As<uintptr_t>(), output_sample_ct, tmp_bytes.data());
 				UnpackPhasedGenotypes(tmp_bytes.data(), preread_phasepresent.As<uintptr_t>(),
 				                      preread_phaseinfo.As<uintptr_t>(), output_sample_ct, preread_phased_pairs.data());
+				// Row-level keep accumulation (phased: diploid sum) from true values.
+				if (row_filter_active) {
+					for (uint32_t s = 0; s < output_sample_ct; s++) {
+						int8_t a1 = preread_phased_pairs[s * 2];
+						if (a1 == -9) {
+							sample_has_missing[s] = 1;
+						} else if (bind_data->genotype_filter.AllowsCall(
+						               static_cast<double>(a1 + preread_phased_pairs[s * 2 + 1]))) {
+							sample_in_range[s] = 1;
+						}
+					}
+				}
 				// Apply genotype_range per-element filtering (phased: check diploid sum)
 				if (bind_data->genotype_filter.active && !genotype_range_all_pass.empty() &&
 				    !genotype_range_all_pass[ev]) {
 					for (uint32_t s = 0; s < output_sample_ct; s++) {
 						int8_t a1 = preread_phased_pairs[s * 2];
 						int8_t a2 = preread_phased_pairs[s * 2 + 1];
-						if (a1 != -9 && !bind_data->genotype_filter.range.Passes(static_cast<double>(a1 + a2))) {
+						if (a1 != -9 && !bind_data->genotype_filter.AllowsCall(static_cast<double>(a1 + a2))) {
 							preread_phased_pairs[s * 2] = -9;
 							preread_phased_pairs[s * 2 + 1] = -9;
 						}
@@ -1313,12 +1361,26 @@ static unique_ptr<FunctionData> PfileBind(ClientContext &context, TableFunctionB
 					throw IOException("read_pfile: PgrGet failed for variant %u during sample-orient pre-read", vidx);
 				}
 				plink2::GenoarrToBytesMinus9(genovec_buf2.As<uintptr_t>(), output_sample_ct, tmp_bytes.data());
-				// Apply genotype_range per-element filtering
-				if (bind_data->genotype_filter.active && !genotype_range_all_pass.empty() &&
-				    !genotype_range_all_pass[ev]) {
+				// Row-level keep accumulation from true values, before any null-out.
+				if (row_filter_active) {
 					for (uint32_t s = 0; s < output_sample_ct; s++) {
 						int8_t geno = tmp_bytes[s];
-						if (geno != -9 && !bind_data->genotype_filter.range.Passes(static_cast<double>(geno))) {
+						if (geno == -9) {
+							sample_has_missing[s] = 1;
+						} else if (bind_data->genotype_filter.AllowsCall(static_cast<double>(geno))) {
+							sample_in_range[s] = 1;
+						}
+					}
+				}
+				// Apply genotype_range per-element null-out for per-element output modes only.
+				// Aggregate modes (counts/stats) must keep true genotype values so that
+				// out-of-range calls are not miscounted as missing (-9) in the counts struct;
+				// genotype_range acts purely as a row filter there.
+				if (bind_data->genotype_filter.active && !genotype_range_all_pass.empty() &&
+				    !genotype_range_all_pass[ev] && !IsAggregateGenotypeMode(bind_data->genotype_mode)) {
+					for (uint32_t s = 0; s < output_sample_ct; s++) {
+						int8_t geno = tmp_bytes[s];
+						if (geno != -9 && !bind_data->genotype_filter.AllowsCall(static_cast<double>(geno))) {
 							tmp_bytes[s] = -9;
 						}
 					}
@@ -1333,6 +1395,20 @@ static unique_ptr<FunctionData> PfileBind(ClientContext &context, TableFunctionB
 			plink2::CleanupPgr(&tmp_pgr, &ce);
 			ce = plink2::kPglRetSuccess;
 			plink2::CleanupPgfi(&tmp_pgfi, &ce);
+		}
+
+		// Build the row-level keep list: a sample is emitted iff it has at least
+		// one genotype in range (or a missing genotype when include_missing is set).
+		// The scan iterates this list instead of all samples, so only surviving
+		// rows materialize.
+		if (row_filter_active) {
+			bind_data->sample_keep.reserve(output_sample_ct);
+			for (uint32_t s = 0; s < output_sample_ct; s++) {
+				if (sample_in_range[s] || (bind_data->genotype_filter.include_missing && sample_has_missing[s])) {
+					bind_data->sample_keep.push_back(s);
+				}
+			}
+			bind_data->has_sample_keep = true;
 		}
 	} else {
 		// Variant mode: same as read_pgen
@@ -1447,8 +1523,17 @@ static unique_ptr<GlobalTableFunctionState> PfileInitGlobal(ClientContext &conte
 				break;
 			}
 		}
+		// A genotype filter must apply regardless of projection: the per-sample
+		// row-skip and its genotype decode are gated on need_genotypes, so force it
+		// on when the filter is active even if the genotype column is not selected.
+		// Otherwise `SELECT IID FROM ... orient:='genotype', include_genotypes:=[...]`
+		// (or any COUNT(*)) would emit every sample of each surviving variant unfiltered.
+		if (bind_data.genotype_filter.active) {
+			state->need_genotypes = true;
+		}
 	} else if (bind_data.orient_mode == OrientMode::SAMPLE) {
-		state->total_count = bind_data.OutputSampleCt();
+		state->total_count =
+		    bind_data.has_sample_keep ? static_cast<uint32_t>(bind_data.sample_keep.size()) : bind_data.OutputSampleCt();
 		// Check if genotypes column(s) are projected
 		state->need_genotypes = false;
 		for (auto col_id : input.column_ids) {
@@ -1802,7 +1887,7 @@ static void PfileDefaultScan(ClientContext &context, TableFunctionInput &data_p,
 								int8_t geno = lstate.genotype_bytes[sample_pos];
 								if (geno == -9 ||
 								    (bind_data.genotype_filter.active && !geno_range_all_pass &&
-								     !bind_data.genotype_filter.range.Passes(static_cast<double>(geno)))) {
+								     !bind_data.genotype_filter.AllowsCall(static_cast<double>(geno)))) {
 									FlatVector::SetNull(vec, rows_emitted, true);
 								} else {
 									FlatVector::GetData<int8_t>(vec)[rows_emitted] = geno;
@@ -1847,7 +1932,7 @@ static void PfileDefaultScan(ClientContext &context, TableFunctionInput &data_p,
 								int8_t geno = lstate.genotype_bytes[s];
 								if (geno == -9 ||
 								    (bind_data.genotype_filter.active && !geno_range_all_pass &&
-								     !bind_data.genotype_filter.range.Passes(static_cast<double>(geno)))) {
+								     !bind_data.genotype_filter.AllowsCall(static_cast<double>(geno)))) {
 									FlatVector::SetNull(child_vec, rows_emitted, true);
 								} else {
 									FlatVector::GetData<int8_t>(child_vec)[rows_emitted] = geno;
@@ -1940,7 +2025,7 @@ static void PfileDefaultScan(ClientContext &context, TableFunctionInput &data_p,
 								idx_t allele_base = pair_idx * 2;
 								int8_t a1 = lstate.phased_pairs[s * 2];
 								int8_t a2 = lstate.phased_pairs[s * 2 + 1];
-								if (a1 == -9 || (!geno_range_all_pass && !bind_data.genotype_filter.range.Passes(
+								if (a1 == -9 || (!geno_range_all_pass && !bind_data.genotype_filter.AllowsCall(
 								                                             static_cast<double>(a1 + a2)))) {
 									pair_validity.SetInvalid(pair_idx);
 									allele_data[allele_base] = 0;
@@ -1963,7 +2048,7 @@ static void PfileDefaultScan(ClientContext &context, TableFunctionInput &data_p,
 								idx_t allele_base = pair_idx * 2;
 								int8_t a1 = lstate.phased_pairs[s * 2];
 								int8_t a2 = lstate.phased_pairs[s * 2 + 1];
-								if (a1 == -9 || (!geno_range_all_pass && !bind_data.genotype_filter.range.Passes(
+								if (a1 == -9 || (!geno_range_all_pass && !bind_data.genotype_filter.AllowsCall(
 								                                             static_cast<double>(a1 + a2)))) {
 									pair_validity.SetInvalid(pair_idx);
 									allele_data[allele_base] = 0;
@@ -2032,7 +2117,7 @@ static void PfileDefaultScan(ClientContext &context, TableFunctionInput &data_p,
 							idx_t base = rows_emitted * array_size;
 							for (idx_t s = 0; s < array_size; s++) {
 								int8_t geno = lstate.genotype_bytes[s];
-								if (geno == -9 || (!geno_range_all_pass && !bind_data.genotype_filter.range.Passes(
+								if (geno == -9 || (!geno_range_all_pass && !bind_data.genotype_filter.AllowsCall(
 								                                               static_cast<double>(geno)))) {
 									child_validity.SetInvalid(base + s);
 									child_data[base + s] = 0;
@@ -2048,7 +2133,7 @@ static void PfileDefaultScan(ClientContext &context, TableFunctionInput &data_p,
 							auto &child_validity = FlatVector::Validity(child);
 							for (idx_t s = 0; s < output_sample_ct; s++) {
 								int8_t geno = lstate.genotype_bytes[s];
-								if (geno == -9 || (!geno_range_all_pass && !bind_data.genotype_filter.range.Passes(
+								if (geno == -9 || (!geno_range_all_pass && !bind_data.genotype_filter.AllowsCall(
 								                                               static_cast<double>(geno)))) {
 									child_validity.SetInvalid(list_offset + s);
 									child_data[list_offset + s] = 0;
@@ -2082,7 +2167,7 @@ static void PfileDefaultScan(ClientContext &context, TableFunctionInput &data_p,
 								int8_t geno = lstate.genotype_bytes[sample_pos];
 								if (geno == -9 ||
 								    (bind_data.genotype_filter.active && !geno_range_all_pass &&
-								     !bind_data.genotype_filter.range.Passes(static_cast<double>(geno)))) {
+								     !bind_data.genotype_filter.AllowsCall(static_cast<double>(geno)))) {
 									FlatVector::SetNull(vec, rows_emitted, true);
 								} else {
 									FlatVector::GetData<int8_t>(vec)[rows_emitted] = geno;
@@ -2267,12 +2352,13 @@ static void PfileTidyScan(ClientContext &context, TableFunctionInput &data_p, Da
 				if (bind_data.include_phased) {
 					int8_t a1 = lstate.phased_pairs[lstate.current_sample_in_variant * 2];
 					if (a1 == -9) {
-						lstate.current_sample_in_variant++;
-						continue;
-					}
-					if (!lstate.geno_range_all_pass) {
+						if (!bind_data.genotype_filter.include_missing) {
+							lstate.current_sample_in_variant++;
+							continue;
+						}
+					} else if (!lstate.geno_range_all_pass) {
 						int8_t a2 = lstate.phased_pairs[lstate.current_sample_in_variant * 2 + 1];
-						if (!bind_data.genotype_filter.range.Passes(static_cast<double>(a1 + a2))) {
+						if (!bind_data.genotype_filter.AllowsCall(static_cast<double>(a1 + a2))) {
 							lstate.current_sample_in_variant++;
 							continue;
 						}
@@ -2280,11 +2366,12 @@ static void PfileTidyScan(ClientContext &context, TableFunctionInput &data_p, Da
 				} else if (!bind_data.include_dosages) {
 					int8_t geno = lstate.genotype_bytes[lstate.current_sample_in_variant];
 					if (geno == -9) {
-						lstate.current_sample_in_variant++;
-						continue;
-					}
-					if (!lstate.geno_range_all_pass &&
-					    !bind_data.genotype_filter.range.Passes(static_cast<double>(geno))) {
+						if (!bind_data.genotype_filter.include_missing) {
+							lstate.current_sample_in_variant++;
+							continue;
+						}
+					} else if (!lstate.geno_range_all_pass &&
+					           !bind_data.genotype_filter.AllowsCall(static_cast<double>(geno))) {
 						lstate.current_sample_in_variant++;
 						continue;
 					}
@@ -2439,8 +2526,11 @@ static void PfileSampleOrientScan(ClientContext &context, TableFunctionInput &da
 		}
 		uint32_t batch_end = std::min(batch_start + claim_size, total_samples);
 
-		for (uint32_t sample_pos = batch_start; sample_pos < batch_end; sample_pos++) {
-			// Map scan-order sample index to file-order sample index
+		for (uint32_t claim_idx = batch_start; claim_idx < batch_end; claim_idx++) {
+			// When a genotype_range row filter is active, the claimed index addresses
+			// the surviving-sample list; otherwise it is the output sample position directly.
+			uint32_t sample_pos = bind_data.has_sample_keep ? bind_data.sample_keep[claim_idx] : claim_idx;
+			// Map output sample position to file-order sample index
 			uint32_t sample_file_idx = bind_data.has_sample_subset ? bind_data.sample_indices[sample_pos] : sample_pos;
 
 			for (idx_t out_col = 0; out_col < column_ids.size(); out_col++) {
@@ -2763,6 +2853,7 @@ void RegisterPfileReader(ExtensionLoader &loader) {
 	read_pfile.named_parameters["af_range"] = LogicalType::ANY;
 	read_pfile.named_parameters["ac_range"] = LogicalType::ANY;
 	read_pfile.named_parameters["genotype_range"] = LogicalType::ANY;
+	read_pfile.named_parameters["include_genotypes"] = LogicalType::LIST(LogicalType::VARCHAR);
 
 	loader.RegisterFunction(read_pfile);
 }

--- a/src/pgen_reader.cpp
+++ b/src/pgen_reader.cpp
@@ -295,15 +295,27 @@ static unique_ptr<FunctionData> PgenBind(ClientContext &context, TableFunctionBi
 		}
 	}
 
-	// --- Parse genotype_range filter ---
+	// --- Parse genotype filter: include_genotypes (canonical) or genotype_range (alias) ---
 	{
+		auto ig_it = input.named_parameters.find("include_genotypes");
 		auto gr_it = input.named_parameters.find("genotype_range");
-		if (gr_it != input.named_parameters.end()) {
-			if (bind_data->include_dosages) {
-				throw InvalidInputException("read_pgen: genotype_range is incompatible with dosages := true");
-			}
-			bind_data->genotype_filter.range = ParseRangeFilter(gr_it->second, "genotype_range", 0.0, 2.0, "read_pgen");
-			bind_data->genotype_filter.active = bind_data->genotype_filter.range.active;
+		bool has_ig = ig_it != input.named_parameters.end();
+		bool has_gr = gr_it != input.named_parameters.end();
+		if (has_ig && has_gr) {
+			throw InvalidInputException(
+			    "read_pgen: specify only one of include_genotypes or genotype_range (genotype_range is the numeric "
+			    "alias of include_genotypes)");
+		}
+		if ((has_ig || has_gr) && bind_data->include_dosages) {
+			throw InvalidInputException("read_pgen: %s is incompatible with dosages := true",
+			                            has_ig ? "include_genotypes" : "genotype_range");
+		}
+		if (has_ig) {
+			ParseIncludeGenotypes(ig_it->second, bind_data->genotype_filter, "read_pgen");
+		} else if (has_gr) {
+			bool inc_missing = false;
+			RangeFilter range = ParseRangeFilter(gr_it->second, "genotype_range", 0.0, 2.0, "read_pgen", &inc_missing);
+			bind_data->genotype_filter.SetFromRange(range, inc_missing);
 		}
 	}
 
@@ -744,7 +756,7 @@ static void PgenScan(ClientContext &context, TableFunctionInput &data_p, DataChu
 								int8_t geno = lstate.genotype_bytes[sample_pos];
 								if (geno == -9 ||
 								    (bind_data.genotype_filter.active && !geno_range_all_pass &&
-								     !bind_data.genotype_filter.range.Passes(static_cast<double>(geno)))) {
+								     !bind_data.genotype_filter.AllowsCall(static_cast<double>(geno)))) {
 									FlatVector::SetNull(vec, rows_emitted, true);
 								} else {
 									FlatVector::GetData<int8_t>(vec)[rows_emitted] = geno;
@@ -789,7 +801,7 @@ static void PgenScan(ClientContext &context, TableFunctionInput &data_p, DataChu
 								int8_t geno = lstate.genotype_bytes[s];
 								if (geno == -9 ||
 								    (bind_data.genotype_filter.active && !geno_range_all_pass &&
-								     !bind_data.genotype_filter.range.Passes(static_cast<double>(geno)))) {
+								     !bind_data.genotype_filter.AllowsCall(static_cast<double>(geno)))) {
 									FlatVector::SetNull(child_vec, rows_emitted, true);
 								} else {
 									FlatVector::GetData<int8_t>(child_vec)[rows_emitted] = geno;
@@ -880,7 +892,7 @@ static void PgenScan(ClientContext &context, TableFunctionInput &data_p, DataChu
 								int8_t a2 = lstate.phased_pairs[s * 2 + 1];
 								if (a1 == -9 ||
 								    (bind_data.genotype_filter.active && !geno_range_all_pass &&
-								     !bind_data.genotype_filter.range.Passes(static_cast<double>(a1 + a2)))) {
+								     !bind_data.genotype_filter.AllowsCall(static_cast<double>(a1 + a2)))) {
 									pair_validity.SetInvalid(pair_idx);
 									allele_data[allele_base] = 0;
 									allele_data[allele_base + 1] = 0;
@@ -905,7 +917,7 @@ static void PgenScan(ClientContext &context, TableFunctionInput &data_p, DataChu
 								int8_t a2 = lstate.phased_pairs[s * 2 + 1];
 								if (a1 == -9 ||
 								    (bind_data.genotype_filter.active && !geno_range_all_pass &&
-								     !bind_data.genotype_filter.range.Passes(static_cast<double>(a1 + a2)))) {
+								     !bind_data.genotype_filter.AllowsCall(static_cast<double>(a1 + a2)))) {
 									pair_validity.SetInvalid(pair_idx);
 									allele_data[allele_base] = 0;
 									allele_data[allele_base + 1] = 0;
@@ -972,7 +984,7 @@ static void PgenScan(ClientContext &context, TableFunctionInput &data_p, DataChu
 								int8_t geno = lstate.genotype_bytes[s];
 								if (geno == -9 ||
 								    (bind_data.genotype_filter.active && !geno_range_all_pass &&
-								     !bind_data.genotype_filter.range.Passes(static_cast<double>(geno)))) {
+								     !bind_data.genotype_filter.AllowsCall(static_cast<double>(geno)))) {
 									child_validity.SetInvalid(base + s);
 									child_data[base + s] = 0;
 								} else {
@@ -990,7 +1002,7 @@ static void PgenScan(ClientContext &context, TableFunctionInput &data_p, DataChu
 								int8_t geno = lstate.genotype_bytes[s];
 								if (geno == -9 ||
 								    (bind_data.genotype_filter.active && !geno_range_all_pass &&
-								     !bind_data.genotype_filter.range.Passes(static_cast<double>(geno)))) {
+								     !bind_data.genotype_filter.AllowsCall(static_cast<double>(geno)))) {
 									child_validity.SetInvalid(list_offset + s);
 									child_data[list_offset + s] = 0;
 								} else {
@@ -1023,7 +1035,7 @@ static void PgenScan(ClientContext &context, TableFunctionInput &data_p, DataChu
 								int8_t geno = lstate.genotype_bytes[sample_pos];
 								if (geno == -9 ||
 								    (bind_data.genotype_filter.active && !geno_range_all_pass &&
-								     !bind_data.genotype_filter.range.Passes(static_cast<double>(geno)))) {
+								     !bind_data.genotype_filter.AllowsCall(static_cast<double>(geno)))) {
 									FlatVector::SetNull(vec, rows_emitted, true);
 								} else {
 									FlatVector::GetData<int8_t>(vec)[rows_emitted] = geno;
@@ -1066,6 +1078,7 @@ void RegisterPgenReader(ExtensionLoader &loader) {
 	read_pgen.named_parameters["af_range"] = LogicalType::ANY;
 	read_pgen.named_parameters["ac_range"] = LogicalType::ANY;
 	read_pgen.named_parameters["genotype_range"] = LogicalType::ANY;
+	read_pgen.named_parameters["include_genotypes"] = LogicalType::LIST(LogicalType::VARCHAR);
 	read_pgen.named_parameters["variants"] = LogicalType::ANY;
 
 	loader.RegisterFunction(read_pgen);

--- a/src/pgen_reader.cpp
+++ b/src/pgen_reader.cpp
@@ -754,9 +754,8 @@ static void PgenScan(ClientContext &context, TableFunctionInput &data_p, DataChu
 								}
 							} else {
 								int8_t geno = lstate.genotype_bytes[sample_pos];
-								if (geno == -9 ||
-								    (bind_data.genotype_filter.active && !geno_range_all_pass &&
-								     !bind_data.genotype_filter.AllowsCall(static_cast<double>(geno)))) {
+								if (geno == -9 || (bind_data.genotype_filter.active && !geno_range_all_pass &&
+								                   !bind_data.genotype_filter.AllowsCall(static_cast<double>(geno)))) {
 									FlatVector::SetNull(vec, rows_emitted, true);
 								} else {
 									FlatVector::GetData<int8_t>(vec)[rows_emitted] = geno;
@@ -799,9 +798,8 @@ static void PgenScan(ClientContext &context, TableFunctionInput &data_p, DataChu
 								}
 							} else {
 								int8_t geno = lstate.genotype_bytes[s];
-								if (geno == -9 ||
-								    (bind_data.genotype_filter.active && !geno_range_all_pass &&
-								     !bind_data.genotype_filter.AllowsCall(static_cast<double>(geno)))) {
+								if (geno == -9 || (bind_data.genotype_filter.active && !geno_range_all_pass &&
+								                   !bind_data.genotype_filter.AllowsCall(static_cast<double>(geno)))) {
 									FlatVector::SetNull(child_vec, rows_emitted, true);
 								} else {
 									FlatVector::GetData<int8_t>(child_vec)[rows_emitted] = geno;
@@ -890,9 +888,8 @@ static void PgenScan(ClientContext &context, TableFunctionInput &data_p, DataChu
 								idx_t allele_base = pair_idx * 2;
 								int8_t a1 = lstate.phased_pairs[s * 2];
 								int8_t a2 = lstate.phased_pairs[s * 2 + 1];
-								if (a1 == -9 ||
-								    (bind_data.genotype_filter.active && !geno_range_all_pass &&
-								     !bind_data.genotype_filter.AllowsCall(static_cast<double>(a1 + a2)))) {
+								if (a1 == -9 || (bind_data.genotype_filter.active && !geno_range_all_pass &&
+								                 !bind_data.genotype_filter.AllowsCall(static_cast<double>(a1 + a2)))) {
 									pair_validity.SetInvalid(pair_idx);
 									allele_data[allele_base] = 0;
 									allele_data[allele_base + 1] = 0;
@@ -915,9 +912,8 @@ static void PgenScan(ClientContext &context, TableFunctionInput &data_p, DataChu
 								idx_t allele_base = pair_idx * 2;
 								int8_t a1 = lstate.phased_pairs[s * 2];
 								int8_t a2 = lstate.phased_pairs[s * 2 + 1];
-								if (a1 == -9 ||
-								    (bind_data.genotype_filter.active && !geno_range_all_pass &&
-								     !bind_data.genotype_filter.AllowsCall(static_cast<double>(a1 + a2)))) {
+								if (a1 == -9 || (bind_data.genotype_filter.active && !geno_range_all_pass &&
+								                 !bind_data.genotype_filter.AllowsCall(static_cast<double>(a1 + a2)))) {
 									pair_validity.SetInvalid(pair_idx);
 									allele_data[allele_base] = 0;
 									allele_data[allele_base + 1] = 0;
@@ -982,9 +978,8 @@ static void PgenScan(ClientContext &context, TableFunctionInput &data_p, DataChu
 							idx_t base = rows_emitted * array_size;
 							for (idx_t s = 0; s < array_size; s++) {
 								int8_t geno = lstate.genotype_bytes[s];
-								if (geno == -9 ||
-								    (bind_data.genotype_filter.active && !geno_range_all_pass &&
-								     !bind_data.genotype_filter.AllowsCall(static_cast<double>(geno)))) {
+								if (geno == -9 || (bind_data.genotype_filter.active && !geno_range_all_pass &&
+								                   !bind_data.genotype_filter.AllowsCall(static_cast<double>(geno)))) {
 									child_validity.SetInvalid(base + s);
 									child_data[base + s] = 0;
 								} else {
@@ -1000,9 +995,8 @@ static void PgenScan(ClientContext &context, TableFunctionInput &data_p, DataChu
 							auto &child_validity = FlatVector::Validity(child);
 							for (idx_t s = 0; s < output_sample_ct; s++) {
 								int8_t geno = lstate.genotype_bytes[s];
-								if (geno == -9 ||
-								    (bind_data.genotype_filter.active && !geno_range_all_pass &&
-								     !bind_data.genotype_filter.AllowsCall(static_cast<double>(geno)))) {
+								if (geno == -9 || (bind_data.genotype_filter.active && !geno_range_all_pass &&
+								                   !bind_data.genotype_filter.AllowsCall(static_cast<double>(geno)))) {
 									child_validity.SetInvalid(list_offset + s);
 									child_data[list_offset + s] = 0;
 								} else {
@@ -1033,9 +1027,8 @@ static void PgenScan(ClientContext &context, TableFunctionInput &data_p, DataChu
 								}
 							} else {
 								int8_t geno = lstate.genotype_bytes[sample_pos];
-								if (geno == -9 ||
-								    (bind_data.genotype_filter.active && !geno_range_all_pass &&
-								     !bind_data.genotype_filter.AllowsCall(static_cast<double>(geno)))) {
+								if (geno == -9 || (bind_data.genotype_filter.active && !geno_range_all_pass &&
+								                   !bind_data.genotype_filter.AllowsCall(static_cast<double>(geno)))) {
 									FlatVector::SetNull(vec, rows_emitted, true);
 								} else {
 									FlatVector::GetData<int8_t>(vec)[rows_emitted] = geno;

--- a/src/plink_common.cpp
+++ b/src/plink_common.cpp
@@ -1263,9 +1263,9 @@ RangeFilter ParseRangeFilter(const Value &val, const string &param_name, double 
 		}
 
 		if (field_name != "min" && field_name != "max") {
-			throw InvalidInputException("%s: %s has unknown field '%s' (expected %s)", func_name, param_name, field_name,
-			                            include_missing_out ? "'min', 'max', and/or 'include_missing'"
-			                                                : "'min' and/or 'max'");
+			throw InvalidInputException(
+			    "%s: %s has unknown field '%s' (expected %s)", func_name, param_name, field_name,
+			    include_missing_out ? "'min', 'max', and/or 'include_missing'" : "'min' and/or 'max'");
 		}
 
 		if (child_val.IsNull()) {

--- a/src/plink_common.cpp
+++ b/src/plink_common.cpp
@@ -1236,7 +1236,7 @@ VariantRange ParseRegion(const string &region_str, const VariantMetadataIndex &v
 // ---------------------------------------------------------------------------
 
 RangeFilter ParseRangeFilter(const Value &val, const string &param_name, double valid_min, double valid_max,
-                             const string &func_name) {
+                             const string &func_name, bool *include_missing_out) {
 	RangeFilter result;
 
 	if (val.type().id() != LogicalTypeId::STRUCT) {
@@ -1255,9 +1255,17 @@ RangeFilter ParseRangeFilter(const Value &val, const string &param_name, double 
 		auto &field_name = child_types[i].first;
 		auto &child_val = children[i];
 
+		if (include_missing_out && field_name == "include_missing") {
+			if (!child_val.IsNull()) {
+				*include_missing_out = child_val.GetValue<bool>();
+			}
+			continue;
+		}
+
 		if (field_name != "min" && field_name != "max") {
-			throw InvalidInputException("%s: %s has unknown field '%s' (expected 'min' and/or 'max')", func_name,
-			                            param_name, field_name);
+			throw InvalidInputException("%s: %s has unknown field '%s' (expected %s)", func_name, param_name, field_name,
+			                            include_missing_out ? "'min', 'max', and/or 'include_missing'"
+			                                                : "'min' and/or 'max'");
 		}
 
 		if (child_val.IsNull()) {
@@ -1283,6 +1291,43 @@ RangeFilter ParseRangeFilter(const Value &val, const string &param_name, double 
 
 	result.active = true;
 	return result;
+}
+
+void ParseIncludeGenotypes(const Value &val, GenotypeRangeFilter &out, const string &func_name) {
+	if (val.type().id() != LogicalTypeId::LIST) {
+		throw InvalidInputException("%s: include_genotypes must be a LIST of category names "
+		                            "(e.g. ['het', 'hom_alt'])",
+		                            func_name);
+	}
+
+	auto &children = ListValue::GetChildren(val);
+	if (children.empty()) {
+		return; // empty list = no filter
+	}
+
+	for (auto &child : children) {
+		if (child.IsNull()) {
+			throw InvalidInputException("%s: include_genotypes contains a NULL category name", func_name);
+		}
+		string label = child.GetValue<string>();
+		StringUtil::Trim(label);
+		label = StringUtil::Lower(label);
+		if (label == "hom_ref") {
+			out.allowed[0] = true;
+		} else if (label == "het") {
+			out.allowed[1] = true;
+		} else if (label == "hom_alt") {
+			out.allowed[2] = true;
+		} else if (label == "missing") {
+			out.include_missing = true;
+		} else {
+			throw InvalidInputException("%s: include_genotypes has unknown category '%s' "
+			                            "(expected 'hom_ref', 'het', 'hom_alt', and/or 'missing')",
+			                            func_name, label);
+		}
+	}
+
+	out.active = true;
 }
 
 bool VariantPassesCountFilter(const CountFilter &filter, const STD_ARRAY_REF(uint32_t, 4) genocounts,
@@ -1312,7 +1357,7 @@ bool VariantPassesCountFilter(const CountFilter &filter, const STD_ARRAY_REF(uin
 // Genotype range filtering (genotype_range)
 // ---------------------------------------------------------------------------
 
-GenotypeRangeResult CheckGenotypeRange(const RangeFilter &filter, const STD_ARRAY_REF(uint32_t, 4) genocounts) {
+GenotypeRangeResult CheckGenotypeRange(const GenotypeRangeFilter &filter, const STD_ARRAY_REF(uint32_t, 4) genocounts) {
 	GenotypeRangeResult result;
 	result.any_pass = false;
 	result.all_pass = true;
@@ -1320,13 +1365,21 @@ GenotypeRangeResult CheckGenotypeRange(const RangeFilter &filter, const STD_ARRA
 	// genocounts: [hom_ref(0), het(1), hom_alt(2), missing(3)]
 	// Genotype values map directly to array indices 0, 1, 2
 	for (int g = 0; g <= 2; g++) {
-		bool in_range = filter.Passes(static_cast<double>(g));
-		if (in_range && genocounts[g] > 0) {
+		bool selected = filter.allowed[g];
+		if (selected && genocounts[g] > 0) {
 			result.any_pass = true;
 		}
-		if (!in_range && genocounts[g] > 0) {
+		if (!selected && genocounts[g] > 0) {
 			result.all_pass = false;
 		}
+	}
+
+	// Missing samples are retained only when include_missing is set; when they are,
+	// a variant whose only kept samples are missing must not be skipped by any_pass.
+	// all_pass is unaffected: missing hardcalls are already emitted as NULL, so the
+	// per-element null-out fast path does not need to account for them.
+	if (filter.include_missing && genocounts[3] > 0) {
+		result.any_pass = true;
 	}
 
 	return result;
@@ -1344,7 +1397,7 @@ PreDecompFilterResult CheckPreDecompFilters(const CountFilter &count_filter, con
 	}
 
 	if (genotype_filter.active) {
-		auto gr = CheckGenotypeRange(genotype_filter.range, genocounts);
+		auto gr = CheckGenotypeRange(genotype_filter, genocounts);
 		if (!gr.any_pass) {
 			result.skip = true;
 			return result;

--- a/test/data/.gitignore
+++ b/test/data/.gitignore
@@ -9,3 +9,6 @@ glm_stress.psam
 glm_stress.log
 glm_stress_covariates.parquet
 glm_stress_phenotypes.parquet
+
+# Large benchmark fixtures (generate_large_sample_fixture.sh) — too big to commit
+large_samples/

--- a/test/data/generate_large_sample_fixture.sh
+++ b/test/data/generate_large_sample_fixture.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+#
+# Generate a large SAMPLE-scale fixture for benchmarking sample-oriented,
+# genotype-filtered queries (e.g. "list subject IDs matching a genotype at one
+# variant") at the scale this extension targets: millions of individuals.
+#
+# This is a BENCHMARK fixture, not a CI fixture — the .psam alone is hundreds of
+# MB at 7M samples, so its output is gitignored (see test/data/.gitignore) and
+# must be regenerated locally rather than committed.
+#
+# Requires: plink2 in PATH (or set PLINK2=/path/to/plink2). The canonical
+# spack path in CLAUDE.md has drifted before; `which plink2` is the source of truth.
+#
+# Usage:
+#   ./generate_large_sample_fixture.sh                 # 1,000,000 samples (default)
+#   N_SAMPLES=5000000 ./generate_large_sample_fixture.sh
+#   N_SAMPLES=10000000 N_VARIANTS=50 ./generate_large_sample_fixture.sh
+#   N_VARIANTS=1000000 N_SAMPLES=100000 ./generate_large_sample_fixture.sh   # wide
+#
+# TWO axes, and they TRADE OFF — the .pgen is dense: size ~= samples x variants / 4
+# bytes, and plink2 generation time scales with the total genotype count
+# (~3e7 genotypes/sec observed). You cannot have 1M variants AND millions of
+# samples: 1M x 10M is ~2.3 TB and hours to build. Pick one stress axis:
+#   * TALL (sample-scale, the default use case): many samples, FEW variants.
+#     A carrier query selects ONE variant, so the sample-orient pre-read is
+#     bounded by the selected variant; the cost lives in the N-row .psam parse
+#     and the row-skip. e.g. N_SAMPLES=10000000 N_VARIANTS=20 (~27 MB, seconds).
+#   * WIDE (variant-scale bind cost): 1M variants with a modest sample count, to
+#     measure the fixed pvar parse + variant-index build a single-variant query
+#     pays for variants it never touches. e.g. N_VARIANTS=1000000 N_SAMPLES=100000
+#     (~23 GB, ~1 h). Real biobank pgens (~500K samples x ~1M variants) are ~125 GB.
+
+set -euo pipefail
+cd "$(dirname "$0")"
+
+PLINK2="${PLINK2:-plink2}"
+N_SAMPLES="${N_SAMPLES:-1000000}"
+N_VARIANTS="${N_VARIANTS:-20}"
+MISSING_GENO_FREQ="${MISSING_GENO_FREQ:-0.02}"   # ~2% missing, so the missing path is exercised
+OUT_DIR="${OUT_DIR:-large_samples}"
+PREFIX="${OUT_DIR}/large_${N_SAMPLES}s_${N_VARIANTS}v"
+
+if ! command -v "$PLINK2" >/dev/null 2>&1; then
+	echo "ERROR: plink2 not found (looked for '$PLINK2'). Set PLINK2=/path/to/plink2." >&2
+	exit 1
+fi
+
+mkdir -p "$OUT_DIR"
+
+echo "Generating ${N_SAMPLES} samples x ${N_VARIANTS} variants (missing geno freq ${MISSING_GENO_FREQ}) -> ${PREFIX}.{pgen,pvar,psam}"
+
+# --dummy <sample ct> <SNP ct> [missing dosage freq] [missing pheno freq]
+#         [{acgt|1234|12}] ...
+# The 3rd positional is the missing-dosage (= missing-genotype) frequency. We do
+# NOT pass 'dosage-freq=', so every dosage stays in {0,1,2} — i.e. hardcalls, which
+# is what the hardcall genotype filter operates on. 'acgt' gives realistic allele
+# codes. The self-validation step below fails loudly if the result is not hardcalls
+# with the expected missingness — do not skip it. (Verified against plink2
+# v2.0.0-a.6.9; run `plink2 --help dummy` if your version differs.)
+"$PLINK2" \
+	--dummy "$N_SAMPLES" "$N_VARIANTS" "$MISSING_GENO_FREQ" acgt \
+	--make-pgen \
+	--out "$PREFIX"
+
+# --- Self-validation: confirm hardcalls (not dosages) and expected missingness ---
+DUCKDB="${DUCKDB:-../../build/release/duckdb}"
+EXT="${EXT:-../../build/release/extension/plinking_duck/plinking_duck.duckdb_extension}"
+if [ -x "$DUCKDB" ] && [ -f "$EXT" ]; then
+	echo
+	echo "Validating generated fixture with the built extension..."
+	# Per-variant counts reading as STRUCT(hom_ref, het, hom_alt, missing) confirms
+	# hardcalls (not dosage output); the missing rate should be ~MISSING_GENO_FREQ.
+	"$DUCKDB" -noheader -list -c "
+LOAD '$(cd ../.. && pwd)/build/release/extension/plinking_duck/plinking_duck.duckdb_extension';
+SELECT 'first_variant: total=' || (genotypes.hom_ref + genotypes.het + genotypes.hom_alt + genotypes.missing)
+       || ' missing_rate=' || round(genotypes.missing::DOUBLE / (genotypes.hom_ref + genotypes.het + genotypes.hom_alt + genotypes.missing), 4)
+FROM read_pfile('${PREFIX}', orient := 'variant', genotypes := 'counts') LIMIT 1;
+" || { echo "VALIDATION FAILED — inspect ${PREFIX}.* (wrong --dummy args? dosage data?)." >&2; exit 1; }
+	echo "Validation OK (expected first_variant_missing_rate ~= ${MISSING_GENO_FREQ})."
+else
+	echo "NOTE: build not found ($DUCKDB); skipping self-validation. Build the extension, then re-run to validate." >&2
+fi
+
+echo
+echo "Done. Benchmark the carrier-ID path with, e.g.:"
+echo "  SELECT IID FROM read_pfile('${PREFIX}',"
+echo "      orient := 'sample', genotypes := 'counts',"
+echo "      variants := ['<one-variant-id>'], include_genotypes := ['het','hom_alt']);"
+echo
+echo "Variant IDs: SELECT ID FROM read_pfile('${PREFIX}', orient := 'variant');"

--- a/test/sql/read_pfile_filter.test
+++ b/test/sql/read_pfile_filter.test
@@ -341,15 +341,16 @@ genotype_range is incompatible with dosages
 # --- genotype_range combined with samples (regression test) ---
 
 # genotype_range + samples in genotype orient mode
-# 3 variants pass (rs4 has no carriers in subset), 2 samples = 6 rows
-# Non-carrier genotypes are NULLed but rows are kept
+# In genotype orient the filter SKIPS non-matching rows (applies regardless of
+# projection). Carriers among SAMPLE1/SAMPLE2 with genotype in {1,2}:
+#   rs1 -> SAMPLE2; rs2 -> SAMPLE1, SAMPLE2; rs3 -> SAMPLE1; rs4 -> none = 4 rows
 query I
 SELECT COUNT(*) FROM read_pfile('test/data/pfile_example',
     orient := 'genotype',
     samples := ['SAMPLE1', 'SAMPLE2'],
     genotype_range := {min: 1, max: 2});
 ----
-6
+4
 
 # genotype_range + samples in variant orient mode
 # 3 of 4 variants have at least one carrier among SAMPLE1/SAMPLE2

--- a/test/sql/read_pfile_genotype_filter.test
+++ b/test/sql/read_pfile_genotype_filter.test
@@ -1,0 +1,278 @@
+# name: test/sql/read_pfile_genotype_filter.test
+# description: include_genotypes named-category filter, genotype_range alias, and sample-orient row-skip
+# group: [sql]
+
+require plinking_duck
+
+# --- Test data reference (pfile_example, 4 variants x 4 samples) ---
+# rs1: [0, 1, 2, NULL]   (SAMPLE1=hom_ref, SAMPLE2=het, SAMPLE3=hom_alt, SAMPLE4=missing)
+# rs2: [1, 1, 0, 2]
+# rs3: [2, NULL, 1, 0]
+# rs4: [0, 0, 1, 2]
+#
+# Sample-orient counts (across all 4 variants):
+#   SAMPLE1: hom_ref=2 het=1 hom_alt=1 missing=0
+#   SAMPLE2: hom_ref=1 het=2 hom_alt=0 missing=1
+#   SAMPLE3: hom_ref=1 het=2 hom_alt=1 missing=0
+#   SAMPLE4: hom_ref=1 het=0 hom_alt=2 missing=1
+
+# =====================================================================
+# Counts-corruption regression (headline bug): out-of-range hardcalls
+# must NOT be counted as missing. All 4 samples carry >=1 het/hom_alt,
+# so all are kept, and their counts must equal the TRUE distribution.
+# =====================================================================
+
+query TIIII
+SELECT IID, genotypes.hom_ref, genotypes.het, genotypes.hom_alt, genotypes.missing
+FROM read_pfile('test/data/pfile_example', orient := 'sample', genotypes := 'counts',
+                include_genotypes := ['het', 'hom_alt'])
+ORDER BY IID;
+----
+SAMPLE1	2	1	1	0
+SAMPLE2	1	2	0	1
+SAMPLE3	1	2	1	0
+SAMPLE4	1	0	2	1
+
+# =====================================================================
+# Sample-orient row-skip: single variant carrier list (the reported use case).
+# rs1 -> only SAMPLE2 (het) and SAMPLE3 (hom_alt); hom_ref and missing dropped.
+# =====================================================================
+
+query T
+SELECT IID FROM read_pfile('test/data/pfile_example', orient := 'sample', genotypes := 'counts',
+                           variants := ['rs1'], include_genotypes := ['het', 'hom_alt'])
+ORDER BY IID;
+----
+SAMPLE2
+SAMPLE3
+
+# genotype_range alias produces the identical result.
+
+query T
+SELECT IID FROM read_pfile('test/data/pfile_example', orient := 'sample', genotypes := 'counts',
+                           variants := ['rs1'], genotype_range := {min: 1, max: 2})
+ORDER BY IID;
+----
+SAMPLE2
+SAMPLE3
+
+# =====================================================================
+# Non-contiguous category set: ['hom_ref', 'hom_alt'] = {0, 2}, which a
+# numeric range cannot express. rs1 -> SAMPLE1 (0) and SAMPLE3 (2).
+# =====================================================================
+
+query T
+SELECT IID FROM read_pfile('test/data/pfile_example', orient := 'sample',
+                           variants := ['rs1'], include_genotypes := ['hom_ref', 'hom_alt'])
+ORDER BY IID;
+----
+SAMPLE1
+SAMPLE3
+
+# =====================================================================
+# 'missing' is a first-class category.
+# rs1 + ['hom_alt', 'missing'] -> SAMPLE3 (hom_alt), SAMPLE4 (missing).
+# =====================================================================
+
+query T
+SELECT IID FROM read_pfile('test/data/pfile_example', orient := 'sample',
+                           variants := ['rs1'], include_genotypes := ['hom_alt', 'missing'])
+ORDER BY IID;
+----
+SAMPLE3
+SAMPLE4
+
+# Category names are case-insensitive and whitespace-trimmed.
+
+query T
+SELECT IID FROM read_pfile('test/data/pfile_example', orient := 'sample',
+                           variants := ['rs1'], include_genotypes := [' Hom_Alt ', 'MISSING'])
+ORDER BY IID;
+----
+SAMPLE3
+SAMPLE4
+
+# =====================================================================
+# Empty vs. include_missing on an all-missing dataset (2 variants x 2 samples).
+# =====================================================================
+
+query I
+SELECT COUNT(*) FROM read_pfile('test/data/all_missing', orient := 'sample', genotypes := 'counts',
+                                include_genotypes := ['het', 'hom_alt']);
+----
+0
+
+query I
+SELECT COUNT(*) FROM read_pfile('test/data/all_missing', orient := 'sample', genotypes := 'counts',
+                                include_genotypes := ['het', 'hom_alt', 'missing']);
+----
+2
+
+# =====================================================================
+# Interaction: sample subset + row filter. The keep list is expressed in
+# output-sample positions and must map correctly through sample_indices.
+# Subset {SAMPLE1, SAMPLE3, SAMPLE4}, rs1, het/hom_alt -> only SAMPLE3.
+# =====================================================================
+
+query T
+SELECT IID FROM read_pfile('test/data/pfile_example', orient := 'sample', variants := ['rs1'],
+                           samples := ['SAMPLE1', 'SAMPLE3', 'SAMPLE4'],
+                           include_genotypes := ['het', 'hom_alt'])
+ORDER BY IID;
+----
+SAMPLE3
+
+# =====================================================================
+# Interaction: af_range (variant filter) + include_genotypes (row filter)
+# in sample orient. af_range {max: 0.4} keeps only rs4 [0,0,1,2];
+# hom_alt row filter -> SAMPLE4.
+# =====================================================================
+
+query T
+SELECT IID FROM read_pfile('test/data/pfile_example', orient := 'sample', genotypes := 'counts',
+                           af_range := {max: 0.4}, include_genotypes := ['hom_alt'])
+ORDER BY IID;
+----
+SAMPLE4
+
+# =====================================================================
+# Behavior change: array/list sample-orient now DROPS rows with no in-range
+# genotype (previously emitted an all-NULL genotypes array). Surviving rows
+# still null out out-of-range elements. rs1 + hom_alt -> only SAMPLE3, [2].
+# =====================================================================
+
+query TT
+SELECT IID, genotypes FROM read_pfile('test/data/pfile_example', orient := 'sample', genotypes := 'list',
+                                      variants := ['rs1'], include_genotypes := ['hom_alt'])
+ORDER BY IID;
+----
+SAMPLE3	[2]
+
+# =====================================================================
+# Genotype orient: row-skip honors include_genotypes / 'missing' consistently.
+# =====================================================================
+
+query TI
+SELECT IID, genotype FROM read_pfile('test/data/pfile_example', orient := 'genotype',
+                                     variants := ['rs1'], include_genotypes := ['het', 'hom_alt'])
+ORDER BY IID;
+----
+SAMPLE2	1
+SAMPLE3	2
+
+# rs1 + ['het', 'missing'] in genotype orient keeps the het row and the missing
+# row (missing genotype emitted as NULL).
+
+query TI
+SELECT IID, genotype FROM read_pfile('test/data/pfile_example', orient := 'genotype',
+                                     variants := ['rs1'], include_genotypes := ['het', 'missing'])
+ORDER BY IID;
+----
+SAMPLE2	1
+SAMPLE4	NULL
+
+# Genotype-orient filter must apply regardless of projection: whether or not the
+# genotype column is selected, COUNT(*)/SELECT IID must see the SAME filtered
+# rows (rs1 het+hom_alt -> SAMPLE2, SAMPLE3). Regression for the projection-
+# pushdown bug where an unselected genotype column skipped the per-sample filter.
+
+query I
+SELECT COUNT(*) FROM read_pfile('test/data/pfile_example', orient := 'genotype',
+                                variants := ['rs1'], include_genotypes := ['het', 'hom_alt']);
+----
+2
+
+query T
+SELECT IID FROM read_pfile('test/data/pfile_example', orient := 'genotype',
+                           variants := ['rs1'], include_genotypes := ['het', 'hom_alt'])
+ORDER BY IID;
+----
+SAMPLE2
+SAMPLE3
+
+# Larger scale, genotype not projected: v10000 carriers = het+hom_alt = 4424.
+
+query I
+SELECT COUNT(*) FROM read_pfile('test/data/wes_chr10', orient := 'genotype',
+                                variants := ['v10000'], include_genotypes := ['het', 'hom_alt']);
+----
+4424
+
+# =====================================================================
+# read_pgen (variant orient) accepts include_genotypes as a variant filter.
+# All 4 variants carry >=1 het/hom_alt.
+# =====================================================================
+
+query I
+SELECT COUNT(*) FROM read_pgen('test/data/pgen_example.pgen', include_genotypes := ['het', 'hom_alt']);
+----
+4
+
+# =====================================================================
+# Non-contiguous set in a per-element output mode (variant orient, columns):
+# ['hom_ref', 'hom_alt'] = {0, 2} nulls out het(1) and missing. rs1 = [0,1,2,NULL].
+# =====================================================================
+
+query TIIII
+SELECT ID, SAMPLE1, SAMPLE2, SAMPLE3, SAMPLE4
+FROM read_pfile('test/data/pfile_example', genotypes := 'columns', variants := ['rs1'],
+                include_genotypes := ['hom_ref', 'hom_alt']);
+----
+rs1	0	NULL	2	NULL
+
+# genotype_range alias with include_missing field (post-refactor). rs1 + {2,2}+missing
+# -> SAMPLE3 (hom_alt) and SAMPLE4 (missing).
+
+query T
+SELECT IID FROM read_pfile('test/data/pfile_example', orient := 'sample', genotypes := 'counts',
+                           variants := ['rs1'], genotype_range := {min: 2, max: 2, include_missing: true})
+ORDER BY IID;
+----
+SAMPLE3
+SAMPLE4
+
+# =====================================================================
+# Multi-batch / parallel row-skip: the sample-orient keep list is claimed in
+# batches across the scan, so it must be exercised with a surviving row count
+# that exceeds a single vector (>2048) while still dropping some rows.
+# wes_chr10 variant v10000: hom_ref=5576, het=3803, hom_alt=621 -> 4424 carriers
+# kept, 5576 dropped. Assert the kept set equals exactly the carriers (self-
+# consistent with variant-orient counts) and that it crosses a vector boundary.
+# =====================================================================
+
+query I
+SELECT (SELECT COUNT(*) FROM read_pfile('test/data/wes_chr10', orient := 'sample', genotypes := 'counts',
+                                        variants := ['v10000'], include_genotypes := ['het', 'hom_alt']))
+     = (SELECT genotypes.het + genotypes.hom_alt FROM read_pfile('test/data/wes_chr10', orient := 'variant',
+                                        genotypes := 'counts', variants := ['v10000']));
+----
+true
+
+query I
+SELECT c > 2048 AND c < 10000
+FROM (SELECT COUNT(*) c FROM read_pfile('test/data/wes_chr10', orient := 'sample', genotypes := 'counts',
+                                        variants := ['v10000'], include_genotypes := ['het', 'hom_alt']));
+----
+true
+
+# =====================================================================
+# Error cases.
+# =====================================================================
+
+statement error
+SELECT IID FROM read_pfile('test/data/pfile_example', orient := 'sample', variants := ['rs1'],
+                           include_genotypes := ['het'], genotype_range := {min: 1});
+----
+specify only one of include_genotypes or genotype_range
+
+statement error
+SELECT IID FROM read_pfile('test/data/pfile_example', orient := 'sample', variants := ['rs1'],
+                           include_genotypes := ['heterozygous']);
+----
+unknown category 'heterozygous'
+
+statement error
+SELECT IID FROM read_pfile('test/data/pfile_example', orient := 'sample', genotypes := 'counts',
+                           dosages := true, include_genotypes := ['het']);
+----
+incompatible with dosages


### PR DESCRIPTION
## Summary

Adds a named-category genotype filter and makes sample-scale carrier queries fast.

### Feature: `include_genotypes`
- `include_genotypes := ['het','hom_alt']` — canonical hardcall genotype filter over categories `hom_ref`/`het`/`hom_alt`/`missing` (case-insensitive; arbitrary, incl. non-contiguous, subsets; `missing` is first-class).
- `genotype_range := {min,max,include_missing}` retained as the numeric alias; both compile to one category mask. Specifying both errors.

### Correctness fixes (sample orient)
- **Counts corruption**: out-of-range hardcalls were nulled to `-9` in the pre-read and miscounted as `missing` in counts/stats. Aggregate modes now report true counts; the filter is a pure row filter there.
- **No row-skip**: sample orient emitted all N rows regardless of the filter. It now builds a `sample_keep` list at bind and the scan iterates it, so carrier queries materialize only matching subjects.
- **Genotype-orient projection bug**: the per-sample filter was gated on the genotype column being projected, so `SELECT IID ...`/`COUNT(*)` returned unfiltered rows. Now applies regardless of projection.

### Performance (carrier lookups at biobank scale)
On a 10M-sample fixture, a single-variant carrier query drops from **~6s to ~0.85s**:
- Prefer the `.psam.parquet` companion (fixed a discovery bug that ignored it when the text `.psam` was present).
- Vectorize the companion consumer (was per-cell `Value` boxing).
- Read psam columns natively from the retained `ColumnDataCollection` instead of materializing 10M+ `std::string`s.

### Tests & docs
- New `test/sql/read_pfile_genotype_filter.test` (counts-corruption regression, non-contiguous sets, `missing`, alias equivalence, subset/af_range interactions, multi-batch >2048 rows, genotype-orient projection independence).
- Updated README, common-parameters, `read_pfile`/`read_pgen` reference, performance guide, P4-003.
- `test/data/generate_large_sample_fixture.sh` for benchmarking (plink2, output gitignored).

All 3896 assertions pass (64 test cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
