### PR TITLE
docs: fix stale '.psam files are small' claim

### DIFF
--- a/docs/guides/performance.md
+++ b/docs/guides/performance.md
@@ -34,7 +34,7 @@ Functions that process `.pgen` files use multi-threaded parallel scanning:
 |----------|----------|-------|
 | `read_plink_vcf` | No | Sequential text VCF parsing |
 | `read_pvar` | No | Sequential text file reading |
-| `read_psam` | No | Sequential text file reading; `.psam` files are small |
+| `read_psam` | No | Sequential text file reading |
 | `read_pgen` | Yes | Per-thread pgenlib readers |
 | `read_pfile` (default) | Yes | Same as `read_pgen` |
 | `read_pfile` (genotype orient) | No | Row expansion is single-threaded |


### PR DESCRIPTION
The performance guide's parallelism table claimed `.psam` files are small. At biobank scale a `.psam` is large (10M samples ≈ 142 MB) and its text parse is a real cost — so the parenthetical was false/misleading. Drops it to match the `read_pvar` row.

Docs-only; no new performance notes added (per request).