### PR TITLE
test: cover parquet-companion psam reads + read_pgen include_genotypes

### DIFF
--- a/test/sql/read_pfile_psam_parquet.test
+++ b/test/sql/read_pfile_psam_parquet.test
@@ -1,0 +1,66 @@
+# name: test/sql/read_pfile_psam_parquet.test
+# description: read_pfile reads psam columns natively from a parquet companion (ColumnDataCollection path) in sample/genotype orient
+# group: [sql]
+
+require plinking_duck
+
+require parquet
+
+# An explicit .parquet psam routes read_pfile's genotype/sample orient through the
+# native ColumnDataCollection path (LoadPfileSampleMetadataFromSource +
+# EmitSampleMetadataColumn / FetchChunk) instead of the text `rows` path — the
+# perf-critical code the text-.psam fixtures never exercise. pfile_example.psam has
+# FID (general varchar), IID (id column), and SEX (special: 0 -> NULL; SAMPLE3=0).
+
+statement ok
+COPY (SELECT * FROM read_psam('test/data/pfile_example.psam'))
+TO '/tmp/plinking_duck_cdc_test.psam.parquet' (FORMAT parquet);
+
+# --- Sample orient: FID + IID + SEX read from the CDC path (SEX 0 -> NULL preserved) ---
+query TTI
+SELECT FID, IID, SEX
+FROM read_pfile('test/data/pfile_example', orient := 'sample',
+                psam := '/tmp/plinking_duck_cdc_test.psam.parquet', genotypes := 'counts')
+ORDER BY IID;
+----
+FAM001	SAMPLE1	1
+FAM001	SAMPLE2	2
+FAM002	SAMPLE3	NULL
+FAM002	SAMPLE4	1
+
+# --- CDC path + include_genotypes row-skip together: keep only hom_alt carriers.
+# Exercises the sample_keep -> sample_file_idx -> FetchChunk mapping. SAMPLE2 (no
+# hom_alt) is dropped. ---
+query TI
+SELECT IID, SEX
+FROM read_pfile('test/data/pfile_example', orient := 'sample',
+                psam := '/tmp/plinking_duck_cdc_test.psam.parquet', genotypes := 'counts',
+                include_genotypes := ['hom_alt'])
+ORDER BY IID;
+----
+SAMPLE1	1
+SAMPLE3	NULL
+SAMPLE4	1
+
+# --- Genotype orient: psam columns from the CDC path, combined with a filter ---
+query TII
+SELECT IID, SEX, genotype
+FROM read_pfile('test/data/pfile_example', orient := 'genotype',
+                psam := '/tmp/plinking_duck_cdc_test.psam.parquet', variants := ['rs1'],
+                include_genotypes := ['het', 'hom_alt'])
+ORDER BY IID;
+----
+SAMPLE2	2	1
+SAMPLE3	NULL	2
+
+# --- Equivalence: the CDC path must produce identical psam columns to the text path ---
+query I
+SELECT COUNT(*) FROM (
+  SELECT FID, IID, SEX FROM read_pfile('test/data/pfile_example', orient := 'sample',
+      psam := '/tmp/plinking_duck_cdc_test.psam.parquet', genotypes := 'counts')
+  EXCEPT
+  SELECT FID, IID, SEX FROM read_pfile('test/data/pfile_example', orient := 'sample',
+      genotypes := 'counts')
+);
+----
+0

--- a/test/sql/read_pgen_filter.test
+++ b/test/sql/read_pgen_filter.test
@@ -161,3 +161,47 @@ statement error
 SELECT * FROM read_pgen('test/data/pgen_example.pgen', genotype_range := {min: 1}, dosages := true);
 ----
 genotype_range is incompatible with dosages
+
+# ========== include_genotypes (named-category filter) on read_pgen ==========
+
+# include_genotypes := ['het','hom_alt'] is the named form of genotype_range {1,2}:
+# identical output (hom_ref and missing nulled out per element).
+query TT
+SELECT ID, genotypes FROM read_pgen('test/data/pgen_example.pgen',
+    include_genotypes := ['het', 'hom_alt']) ORDER BY ID;
+----
+rs1	[NULL, 1, 2, NULL]
+rs2	[1, 1, NULL, 2]
+rs3	[2, NULL, 1, NULL]
+rs4	[NULL, NULL, 1, 2]
+
+# Non-contiguous set ['hom_ref','hom_alt'] = {0, 2} — nulls out het(1) and missing.
+# A numeric genotype_range cannot express this.
+query TT
+SELECT ID, genotypes FROM read_pgen('test/data/pgen_example.pgen',
+    include_genotypes := ['hom_ref', 'hom_alt']) ORDER BY ID;
+----
+rs1	[0, NULL, 2, NULL]
+rs2	[NULL, NULL, 0, 2]
+rs3	[2, NULL, NULL, 0]
+rs4	[0, 0, NULL, 2]
+
+# Specifying both include_genotypes and genotype_range is an error.
+statement error
+SELECT ID FROM read_pgen('test/data/pgen_example.pgen',
+    include_genotypes := ['het'], genotype_range := {min: 1});
+----
+specify only one of include_genotypes or genotype_range
+
+# include_genotypes is incompatible with dosages.
+statement error
+SELECT ID FROM read_pgen('test/data/pgen_example.pgen',
+    include_genotypes := ['het'], dosages := true);
+----
+incompatible with dosages
+
+# Unknown category label errors.
+statement error
+SELECT ID FROM read_pgen('test/data/pgen_example.pgen', include_genotypes := ['carrier']);
+----
+unknown category 'carrier'


### PR DESCRIPTION
Closes two test-coverage gaps in the v0.6.0 changes (both were only manually verified):

1. **The native `.psam.parquet` read path** — `read_pfile_psam_parquet.test` reads psam columns (FID / IID / SEX incl. `0 → NULL`) through the `ColumnDataCollection` + `FetchChunk` path in **sample and genotype orient**, combined with `include_genotypes` row-skip (exercising the `sample_keep → sample_file_idx → FetchChunk` mapping), plus an `EXCEPT` equivalence check vs the text path. `parquet_companions.test` only covered `read_pgen` (variant orient), which never hits this code.
2. **`read_pgen` + `include_genotypes`** — previously one assertion; now alias-equivalence with `genotype_range`, a non-contiguous set, and the error cases.

Test-only. Full suite: 3941 assertions / 65 cases.